### PR TITLE
Snap details page

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,10 @@ import humanize
 
 
 app = Flask(__name__)
-cached_request = CachedSession(expire_after=60)
+cached_request = CachedSession(
+    expire_after=60,
+    old_data_on_error=True
+)
 snap_details_url = (
     "https://api.snapcraft.io/api/v1/snaps/details/{snap_name}"
     "?channel=stable"
@@ -17,8 +20,9 @@ snap_details_url = (
 def page_not_found(error):
     return render_template('404.html', description=error.description), 404
 
+
 @app.route('/<snap_name>/')
-def page_not_found(snap_name):
+def snap_details(snap_name):
     query_headers = {
         'X-Ubuntu-Series': '16',
     }
@@ -68,4 +72,3 @@ def page_not_found(snap_name):
         'snap-details.html',
         **context
     )
-

--- a/app.py
+++ b/app.py
@@ -1,3 +1,9 @@
+"""
+A Flask application for snapcraft.io.
+
+The web frontend for the snap store.
+"""
+
 import flask
 import requests
 import requests_cache
@@ -19,6 +25,11 @@ snap_details_url = (
 
 @app.errorhandler(404)
 def page_not_found(error):
+    """
+    For 404 pages, display the 404.html template,
+    passing through the error description.
+    """
+
     return flask.render_template(
         '404.html', description=error.description
     ), 404
@@ -26,6 +37,14 @@ def page_not_found(error):
 
 @app.route('/<snap_name>/')
 def snap_details(snap_name):
+    """
+    A view to display the snap details page for specific snaps.
+
+    This queries the snapcraft API (api.snapcraft.io) and passes
+    some of the data through to the snap-details.html template,
+    with appropriate sanitation.
+    """
+
     query_headers = {
         'X-Ubuntu-Series': '16',
     }

--- a/app.py
+++ b/app.py
@@ -110,6 +110,7 @@ def snap_details(snap_name):
 
         # Context info
         'api_error': response.old_data_from_error,
+        'is_linux': 'Linux' in flask.request.headers['User-Agent']
     }
 
     return flask.render_template(

--- a/app.py
+++ b/app.py
@@ -1,7 +1,71 @@
-from flask import Flask, render_template
+from flask import abort, Flask, render_template
+from requests_cache import CachedSession
+from dateutil import parser
+import json
+import humanize
+
+
 app = Flask(__name__)
+cached_request = CachedSession(expire_after=60)
+snap_details_url = (
+    "https://api.snapcraft.io/api/v1/snaps/details/{snap_name}"
+    "?channel=stable"
+)
 
 
 @app.errorhandler(404)
 def page_not_found(error):
     return render_template('404.html', description=error.description), 404
+
+@app.route('/<snap_name>/')
+def page_not_found(snap_name):
+    query_headers = {
+        'X-Ubuntu-Series': '16',
+    }
+
+    response = cached_request.get(
+        snap_details_url.format(snap_name=snap_name),
+        headers=query_headers,
+        timeout=2
+    )
+
+    if response.status_code >= 400:
+        message = (
+            'Failed to get snap details for {snap_name}'.format(**locals())
+        )
+
+        if response.status_code == 404:
+            message = 'Snap not found: {snap_name}'.format(**locals())
+
+        abort(response.status_code, message)
+
+    snap_data = json.loads(response.text)
+
+    context = {
+        # Always available
+        'name': snap_data['title'],
+        'version': snap_data['version'],
+        'revision': snap_data['revision'],
+        'filesize': humanize.naturalsize(snap_data['binary_filesize']),
+        'download_url': snap_data['download_url'],
+        'publisher': snap_data['publisher'],
+        'screenshot_urls': snap_data['screenshot_urls'],
+        'prices': snap_data['prices'],
+        'support_url': snap_data.get('support_url'),
+        'last_updated': (
+            humanize.naturaldate(
+                parser.parse(snap_data.get('last_updated'))
+            )
+        ),
+
+        # May be available
+        'summary': snap_data.get('summary'),
+        'description': snap_data.get('description'),
+        'icon_url': snap_data.get('icon_url'),
+    }
+
+    return render_template(
+        'snap-details.html',
+        **context
+    )
+

--- a/app.py
+++ b/app.py
@@ -92,7 +92,6 @@ def snap_details(snap_name):
         'icon_url': snap_data['icon_url'],
         'version': snap_data['version'],
         'revision': snap_data['revision'],
-        'download_url': snap_data['download_url'],
         'publisher': snap_data['publisher'],
         'screenshot_urls': snap_data['screenshot_urls'],
         'prices': snap_data['prices'],

--- a/app.py
+++ b/app.py
@@ -1,15 +1,16 @@
-from flask import abort, Flask, render_template
-from requests_cache import CachedSession
-from dateutil import parser
+import flask
+import requests
+import requests_cache
+import datetime
 import json
 import humanize
+from dateutil import parser
 
 
-app = Flask(__name__)
-cached_request = CachedSession(
-    expire_after=60,
-    old_data_on_error=True
-)
+app = flask.Flask(__name__)
+uncached_session = requests.Session()
+cached_session = requests_cache.CachedSession(expire_after=60)
+request_timeout = 2
 snap_details_url = (
     "https://api.snapcraft.io/api/v1/snaps/details/{snap_name}"
     "?channel=stable"
@@ -18,7 +19,9 @@ snap_details_url = (
 
 @app.errorhandler(404)
 def page_not_found(error):
-    return render_template('404.html', description=error.description), 404
+    return flask.render_template(
+        '404.html', description=error.description
+    ), 404
 
 
 @app.route('/<snap_name>/')
@@ -27,10 +30,9 @@ def snap_details(snap_name):
         'X-Ubuntu-Series': '16',
     }
 
-    response = cached_request.get(
+    response = _get_from_cache(
         snap_details_url.format(snap_name=snap_name),
-        headers=query_headers,
-        timeout=2
+        headers=query_headers
     )
 
     if response.status_code >= 400:
@@ -41,13 +43,14 @@ def snap_details(snap_name):
         if response.status_code == 404:
             message = 'Snap not found: {snap_name}'.format(**locals())
 
-        abort(response.status_code, message)
+        flask.abort(response.status_code, message)
 
     snap_data = json.loads(response.text)
 
     context = {
         # Always available
         'name': snap_data['title'],
+        'api_error': response.old_data_from_error,
         'version': snap_data['version'],
         'revision': snap_data['revision'],
         'filesize': humanize.naturalsize(snap_data['binary_filesize']),
@@ -68,7 +71,52 @@ def snap_details(snap_name):
         'icon_url': snap_data.get('icon_url'),
     }
 
-    return render_template(
+    return flask.render_template(
         'snap-details.html',
         **context
     )
+
+
+def _get_from_cache(url, headers):
+    """
+    Retrieve the response from the requests cache.
+    If the cache has expired then it will attempt to update the cache.
+    If it gets an error, it will use the cached response, if it exists.
+    """
+
+    request_error = False
+
+    request = cached_session.prepare_request(
+        requests.Request(
+            method='GET',
+            url=url,
+            headers=headers
+        )
+    )
+
+    cache_key = cached_session.cache.create_key(request)
+    response, timestamp = cached_session.cache.get_response_and_time(
+        cache_key
+    )
+
+    if response:
+        age = datetime.datetime.utcnow() - timestamp
+
+        if age > cached_session._cache_expire_after:
+            try:
+                new_response = uncached_session.send(
+                    request,
+                    timeout=request_timeout
+                )
+                if response.status_code >= 500:
+                    new_response.raise_for_status()
+            except:
+                request_error = True
+            else:
+                response = new_response
+    else:
+        response = cached_session.send(request)
+
+    response.old_data_from_error = request_error
+
+    return response

--- a/app.py
+++ b/app.py
@@ -3,5 +3,5 @@ app = Flask(__name__)
 
 
 @app.errorhandler(404)
-def page_not_found(e):
-    return render_template('404.html'), 404
+def page_not_found(error):
+    return render_template('404.html', description=error.description), 404

--- a/app.py
+++ b/app.py
@@ -11,10 +11,23 @@ import datetime
 import json
 import humanize
 from dateutil import parser
+from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 
 
 app = flask.Flask(__name__)
+
+# Setup session to retry requests 5 times
 uncached_session = requests.Session()
+retries = Retry(
+    total=5,
+    backoff_factor=0.1,
+    status_forcelist=[500, 502, 503, 504]
+)
+uncached_session.mount(
+    'https://api.snapcraft.io',
+    HTTPAdapter(max_retries=retries)
+)
 cached_session = requests_cache.CachedSession(expire_after=60)
 request_timeout = 2
 snap_details_url = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 Flask==0.12.2
+python-dateutil==2.6.1
+humanize==0.5.1
+requests-cache==0.4.13

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -2,5 +2,6 @@
 @include vanilla-base;
 @include vf-p-grid;
 @include vf-p-navigation;
+@include vf-p-notification;
 @include vf-p-footer;
 

--- a/templates/404.html
+++ b/templates/404.html
@@ -9,7 +9,7 @@
     </div>
     <div class="col-6">
       <h1>404: Page not found</h1>
-      <p>Sorry, we couldn&rsquo;t find that page.</p>
+      <p>{{ description }}</p>
     </div>
   </div>
 {% endblock %}

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -7,7 +7,9 @@
     <div class="col-8">
       <h1>{{ name }}</h1>
 
-      <p><a href="{{ download_url }}">Download</a> | <a href="snap://{{ name }}">Install</a></p>
+      {% if is_linux %}
+        <p><a href="snap://{{ name }}">Install</a></p>
+      {% endif %}
 
       {% if api_error %}
         <div class="p-notification--negative">

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -8,7 +8,15 @@
       <h1>{{ name }}</h1>
 
       <p><a href="{{ download_url }}">Download</a> | <a href="snap://{{ name }}">Install</a></p>
-      
+
+      {% if api_error %}
+        <div class="p-notification--negative">
+          <p class="p-notification__response">
+            <span class="p-notification__status">Error:</span> API request failed
+          </p>
+        </div>
+      {% endif %}
+
       <table>
         {% if summary %}<tr><th>Summary</th><td>{{ summary }}</td></tr>{% endif %}
         {% if description %}<tr><th>Description</th><td>{{ description }}</td></tr>{% endif %}
@@ -32,4 +40,3 @@
       {% endif %}
   </div>
 {% endblock %}
-

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -1,0 +1,35 @@
+{% extends "_layout.html" %}
+
+{% block title %}{{ name }} snap details{% endblock %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-8">
+      <h1>{{ name }}</h1>
+
+      <p><a href="{{ download_url }}">Download</a> | <a href="snap://{{ name }}">Install</a></p>
+      
+      <table>
+        {% if summary %}<tr><th>Summary</th><td>{{ summary }}</td></tr>{% endif %}
+        {% if description %}<tr><th>Description</th><td>{{ description }}</td></tr>{% endif %}
+        <tr><th>Latest version</th><td>{{ version }}</td></tr>
+        <tr><th>Last updated</th><td>{{ last_updated }}</td></tr>
+        <tr><th>Filesize</th><td>{{ filesize }}</td></tr>
+        <tr><th>Publisher</th><td>{{ publisher }}</td></tr>
+        {% if support_url %}<tr><th>Contact</th><td><a href="{{ support_url }}">Support</a></td></tr>{% endif %}
+        {% if prices %}<tr><th>Prices</th><td>{{ prices | join(" | ") }}</td></tr>{% endif %}
+      </table>
+    </div>
+
+    <div class="col-4">
+      {% if icon_url %}
+        <img src="{{ icon_url }}" src="{{ name }} snap" />
+      {% endif %}
+      {% if screenshots %}
+        {% for screenshot_url in screenshot_urls %}
+          <img src="{{ screenshot_url }}" />
+        {% endfor %}
+      {% endif %}
+  </div>
+{% endblock %}
+

--- a/tests.py
+++ b/tests.py
@@ -10,9 +10,28 @@ class WebAppTestCase(unittest.TestCase):
         self.app.testing = True
 
     def test_no_homepage(self):
-        homepage_request = self.app.get('/')
-        assert homepage_request.status_code == 404
-        assert "Page not found" in str(homepage_request.data)
+        response = self.app.get('/')
+        assert response.status_code == 404
+        assert "Page not found" in str(response.data)
+
+    def test_redirect_to_add_slash(self):
+        response = self.app.get('/canonical-livepatch')
+        location = response.headers.get('Location')
+
+        assert response.status_code in (301,302)
+        assert location == "http://localhost/canonical-livepatch/"
+
+    def test_canonical_livepatch_snap(self):
+        response = self.app.get('/canonical-livepatch/')
+
+        assert response.status_code == 200
+
+    def test_non_existent_snap(self):
+        response = self.app.get('/non-existent-snap/')
+
+        assert response.status_code == 404
+        assert "Snap not found" in str(response.data)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #3
Fixes #4

- A snap details template
- A default view to process all URLs matching `/<something>`
- Only look for public snaps in the stable channel
- Cause a 404 with a custom error message if snap not found
- Use vanilla markup syntax ready for merging with #10

## Implementation

Could the relevant people please comment on these implementation details to let me know if they seem sensible.

### Data passed to the template

I am only passing through certain data to the template, according to what @matthewpaulthomas listed in https://github.com/CanonicalLtd/snappy-design-squad/issues/69#issuecomment-320259725 - I am providing all the data with ticks next to them, except the geo location data which isn't yet available.

The data that's passed through can easily be updated in `app.py`, but each datum should always be explicitly passed through, rather than transparently returning everything from the API.

@matthewpaulthomas please comment on this.

### Caching and timeout

The application will maintain a cache of its API requests for 60 seconds. Any subsequent requests from the same application instance within 60 seconds of the first request will therefore be served from the cache, rather than querying the API directly. This should mean that within each minute, the application should only be call a maximum of the number of times corresponding with how many app units are running. 4 units = 4 times a minute.

Each API request will timeout after 2 seconds. This is to prevent the application delaying significantly to respond to the user.

On any error (timeouts, connection errors or HTTP statuses above 499), the application will return a response from the cache if available, along with a notification that there was an API error.

@cprov would you or someone else from the Store side mind commenting on my implementation here? Let me know if it seems sensible to you?

## QA instructions

``` bash
python3 -m venv env3
source env3/bin/activate
pip install -r requirements.txt
FLASK_APP=app.py FLASK_DEBUG=true flask run
```

Now browse to:

- http://127.0.0.1:5000/canonical-livepatch/
- http://127.0.0.1:5000/documentation-builder/
- http://127.0.0.1:5000/non-existent-snap/

And check each page shows what is expected.