### PR TITLE
Added basic grid layout to snap detail page

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "node-sass": "^4.5.3",
     "sass-lint": "^1.10.2",
-    "vanilla-framework": "1.4.3"
+    "vanilla-framework": "1.5.1"
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,7 +1,8 @@
 @import 'vanilla-framework/scss/vanilla';
 @include vanilla-base;
 @include vf-p-grid;
+@include vf-p-grid-modifications;
+@include vf-p-strip;
 @include vf-p-navigation;
 @include vf-p-notification;
 @include vf-p-footer;
-

--- a/templates/404.html
+++ b/templates/404.html
@@ -3,6 +3,7 @@
 {% block title %}404: Page not found{% endblock %}
 
 {% block content %}
+<div class="p-strip">
   <div class="row">
     <div class="col-6">
       <img src="/static/confused-hex.svg" />
@@ -12,5 +13,5 @@
       <p>{{ description }}</p>
     </div>
   </div>
+</div>
 {% endblock %}
-

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -3,10 +3,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %}</title>
     <link rel="stylesheet" href="/static/css/styles.css" />
   </head>
-  
+
   <body>
     <header id="navigation" class="p-navigation--light">
       <div class="row">
@@ -20,9 +22,7 @@
       </div>
     </header>
 
-    <div id="main-content" class="p-strip is-deep u-no-padding--bottom">
-      {% block content %}{% endblock %}
-    </div>
+    {% block content %}{% endblock %}
 
     <footer class="p-footer u-no-margin--top">
       <div class="row">
@@ -33,4 +33,3 @@
     </footer>
   </body>
 </html>
-

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -3,42 +3,48 @@
 {% block title %}{{ name }} snap details{% endblock %}
 
 {% block content %}
+  <div class="p-strip">
+    <div class="row">
+      <div class="col-2">
+        {% if icon_url %}
+          <img src="{{ icon_url }}" alt="{{ name }} snap" />
+        {% else %}
+          <img src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="" />
+        {% endif %}
+      </div>
+      <div class="col-10">
+        <h1>{{ name }}</h1>
+        <p>{{ publisher }}</p>
+
+        {% if is_linux %}
+        <p><a href="snap://{{ name }}">Install</a></p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
   <div class="row">
     <div class="col-8">
-      <h1>{{ name }}</h1>
-
-      {% if is_linux %}
-        <p><a href="snap://{{ name }}">Install</a></p>
-      {% endif %}
-
-      {% if api_error %}
-        <div class="p-notification--negative">
-          <p class="p-notification__response">
-            <span class="p-notification__status">Error:</span> API request failed
-          </p>
-        </div>
-      {% endif %}
-
+      {% if summary %}<h2>{{ summary }}</h2>{% endif %}
+      {% if description %}<p>{{ description }}</p>{% endif %}
+      {% if support_url %}<p><a href="{{ support_url }}">Developer website</a></p>{% endif %}
+    </div>
+    <div class="col-4">
       <table>
-        {% if summary %}<tr><th>Summary</th><td>{{ summary }}</td></tr>{% endif %}
-        {% if description %}<tr><th>Description</th><td>{{ description }}</td></tr>{% endif %}
         <tr><th>Latest version</th><td>{{ version }}</td></tr>
         <tr><th>Last updated</th><td>{{ last_updated }}</td></tr>
         <tr><th>Filesize</th><td>{{ filesize }}</td></tr>
-        <tr><th>Publisher</th><td>{{ publisher }}</td></tr>
-        {% if support_url %}<tr><th>Contact</th><td><a href="{{ support_url }}">Support</a></td></tr>{% endif %}
-        {% if prices %}<tr><th>Prices</th><td>{{ prices | join(" | ") }}</td></tr>{% endif %}
       </table>
     </div>
-
-    <div class="col-4">
-      {% if icon_url %}
-        <img src="{{ icon_url }}" src="{{ name }} snap" />
-      {% endif %}
-      {% if screenshots %}
-        {% for screenshot_url in screenshot_urls %}
-          <img src="{{ screenshot_url }}" />
-        {% endfor %}
-      {% endif %}
   </div>
+  {% if api_error %}
+  <div class="row">
+    <div class="col-12">
+      <div class="p-notification--negative">
+        <p class="p-notification__response">
+          <span class="p-notification__status">Error:</span> API request failed
+        </p>
+      </div>
+    </div>
+  </div>
+  {% endif %}
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1567,9 +1567,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.4.3.tgz#259386f083fcaa8193c22bad6a3d1148e0cc4481"
+vanilla-framework@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.5.1.tgz#da3a3da7ca170cb444dae54fcc660b2fc305ce7c"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Adds simple responsive layout to snap details page.

Fixes #14

### QA instructions

```
python3 -m venv env3
source env3/bin/activate
pip install -r requirements.txt
yarn install
FLASK_APP=app.py FLASK_DEBUG=true flask run
```

Now browse to:

http://127.0.0.1:5000/canonical-livepatch/
http://127.0.0.1:5000/documentation-builder/
http://127.0.0.1:5000/non-existent-snap/

And check each page shows what is expected.

### Screenshots

<img width="413" alt="screen shot 2017-09-01 at 17 28 31" src="https://user-images.githubusercontent.com/83575/29976710-363e1b62-8f3b-11e7-8215-b9ba9c9090a1.png">
<img width="1033" alt="screen shot 2017-09-01 at 17 28 08" src="https://user-images.githubusercontent.com/83575/29976711-364039c4-8f3b-11e7-9fe1-15e5e1fa0da0.png">
