### PR TITLE
Vanilla styling for snap details and install button

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -3,6 +3,7 @@
 @include vanilla-base;
 @include vf-p-grid;
 @include vf-p-grid-modifications;
+@include vf-p-buttons;
 @include vf-p-strip;
 @include vf-p-navigation;
 @include vf-p-notification;

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -3,7 +3,7 @@
 {% block title %}{{ name }} snap details{% endblock %}
 
 {% block content %}
-  <div class="p-strip">
+  <div class="p-strip is-shallow is-bordered">
     <div class="row">
       <div class="col-2">
         {% if icon_url %}
@@ -17,23 +17,27 @@
         <p>{{ publisher }}</p>
 
         {% if is_linux %}
-        <p><a href="snap://{{ name }}">Install</a></p>
+          <p>
+            <a class="p-button--positive" href="snap://{{ name }}">Install</a>
+          </p>
         {% endif %}
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-8">
-      {% if summary %}<h2>{{ summary }}</h2>{% endif %}
-      {% if description %}<p>{{ description }}</p>{% endif %}
-      {% if support_url %}<p><a href="{{ support_url }}">Developer website</a></p>{% endif %}
-    </div>
-    <div class="col-4">
-      <table>
-        <tr><th>Latest version</th><td>{{ version }}</td></tr>
-        <tr><th>Last updated</th><td>{{ last_updated }}</td></tr>
-        <tr><th>Filesize</th><td>{{ filesize }}</td></tr>
-      </table>
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-8">
+        {% if summary %}<h2>{{ summary }}</h2>{% endif %}
+        {% if description %}<p>{{ description }}</p>{% endif %}
+        {% if support_url %}<p><a href="{{ support_url }}">Developer website</a></p>{% endif %}
+      </div>
+      <div class="col-4">
+        <table>
+          <tr><th>Latest version</th><td>{{ version }}</td></tr>
+          <tr><th>Last updated</th><td>{{ last_updated }}</td></tr>
+          <tr><th>Filesize</th><td>{{ filesize }}</td></tr>
+        </table>
+      </div>
     </div>
   </div>
   {% if api_error %}


### PR DESCRIPTION
Added Vanilla styling for snap details banner (icon, name & install button).

Fixes #17

Designs: https://github.com/CanonicalLtd/snapcraft-design/issues/54#issuecomment-326014685

<img width="412" alt="screen shot 2017-09-05 at 15 00 40" src="https://user-images.githubusercontent.com/83575/30062377-392d2990-924b-11e7-9b37-52970daba664.png">

<img width="1021" alt="screen shot 2017-09-05 at 15 00 26" src="https://user-images.githubusercontent.com/83575/30062376-39266ce0-924b-11e7-9f5e-ed6e6b9c4f62.png">

From the designs it looks it was meant to be similar to Media Pattern (https://docs.vanillaframework.io/en/patterns/media-object), but Media Pattern is much smaller (icon and heading) and simply doesn't look good as a main object on the top of the page.

We probably need a bigger variant of media pattern for that.
I added a proposal for that (https://github.com/vanilla-framework/vanilla-framework/issues/1315)