### PR TITLE
Use latest node image in ./run

### DIFF
--- a/run
+++ b/run
@@ -46,7 +46,7 @@ Commands
 # Define docker images versions
 python_image="canonicalwebteam/python3:v1.1.0"
 bundler_image="canonicalwebteam/bundler:v0.1.2"
-node_image="canonicalwebteam/node:v0.2.0"
+node_image="canonicalwebteam/node:v0.2.1"
 
 # Global volume names
 yarn_cache_volume="${CANONICAL_WEBTEAM_YARN_CACHE_VOLUME:-canonical-webteam-node-cache}"


### PR DESCRIPTION
The old node image was actually preventing node-sass installing properly. So we use the new node image which *downgrades* to Node 7.

QA
--

``` bash
./run clean
./run
```