### PR TITLE
Vanilla styling for description and snap details

### DIFF
--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -24,7 +24,7 @@
   </div>
   <div class="row">
     <div class="col-8">
-      {% if summary %}<h2>{{ summary }}</h2>{% endif %}
+      {% if summary %}<h4>{{ summary }}</h4>{% endif %}
       {% for paragraph in description_paragraphs %}
         <p>{{ paragraph }}</p>
       {% endfor %}
@@ -32,9 +32,8 @@
     </div>
     <div class="col-4">
       <table>
-        <tr><th>Latest version</th><td>{{ version }}</td></tr>
-        <tr><th>Last updated</th><td>{{ last_updated }}</td></tr>
-        <tr><th>Filesize</th><td>{{ filesize }}</td></tr>
+        <tr><th>Version</th><td>{{ version }}</td></tr>
+        <tr><th>Size</th><td>{{ filesize }}</td></tr>
       </table>
     </div>
   </div>


### PR DESCRIPTION
Updated styles for snap description and details table.

Fixes #18 
Fixes #19 

### QA

- ./run
- Visit http://localhost:8022/gnome-calculator/ or http://localhost:8022/dwarf-fortress/
- Snap description and details table should have vanilla styles as per design

<img width="1014" alt="screen shot 2017-09-06 at 12 52 35" src="https://user-images.githubusercontent.com/83575/30108360-520d8164-9302-11e7-929a-1995c9e02999.png">
