### PR TITLE
Rename title and add package_name

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,7 +89,8 @@ def snap_details(snap_name):
 
     context = {
         # Data direct from API
-        'name': snap_data['title'],
+        'snap_title': snap_data['title'],
+        'package_name': snap_data['package_name'],
         'icon_url': snap_data['icon_url'],
         'version': snap_data['version'],
         'revision': snap_data['revision'],

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -1,24 +1,24 @@
 {% extends "_layout.html" %}
 
-{% block title %}{{ name }} snap details{% endblock %}
+{% block title %}{{ snap_title }} snap details{% endblock %}
 
 {% block content %}
   <div class="p-strip is-shallow is-bordered">
     <div class="row">
       <div class="col-2">
         {% if icon_url %}
-          <img src="{{ icon_url }}" alt="{{ name }} snap" />
+          <img src="{{ icon_url }}" alt="{{ snap_title }} snap" />
         {% else %}
           <img src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="" />
         {% endif %}
       </div>
       <div class="col-10">
-        <h1>{{ name }}</h1>
+        <h1>{{ snap_title }}</h1>
         <p>{{ publisher }}</p>
 
         {% if is_linux %}
           <p>
-            <a class="p-button--positive" href="snap://{{ name }}">Install</a>
+            <a class="p-button--positive" href="snap://{{ package_name }}">Install</a>
           </p>
         {% endif %}
       </div>


### PR DESCRIPTION
I noticed that we were using the `title` for both the "heading" and in the snap URL (`snap://{{ name }}`). This was my mistake - because `title` and `package_name` happened to be the same for `canonical-livepatch` I thought they were always the same.

I'm now passing through `snap_title` and `package_name` separately, and using them where appropriate.

QA
--

`./run` and visit <http://0.0.0.0:8022/dwarf-fortress/>. Check the "install" link works.