### PR TITLE
Simple Vanilla footer

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -8,3 +8,4 @@
 @include vf-p-notification;
 @include vf-p-footer;
 @include vf-u-floats;
+@include vf-u-off-screen;

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -28,6 +28,16 @@
       <div class="row">
         <div class="col-12">
           &copy; 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
+          <nav>
+            <ul class="p-footer__links">
+                <li class="p-footer__item"><a class="p-footer__link" href="http://www.ubuntu.com/legal">Legal information</a></li>
+                <li class="p-footer__item"><a class="p-footer__link" href="https://github.com/ubuntudesign/snapcraft.io/issues/new">Report a bug on this site</a></li>
+                <li class="p-footer__item"><a class="p-footer__link" href="http://status.snapcraft.io/">Service status</a></li>
+            </ul>
+            <span class="u-off-screen">
+              <a href="#">Go to the top of the page</a>
+            </span>
+          </nav>
         </div>
       </div>
     </footer>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -31,7 +31,7 @@
           <nav>
             <ul class="p-footer__links">
                 <li class="p-footer__item"><a class="p-footer__link" href="http://www.ubuntu.com/legal">Legal information</a></li>
-                <li class="p-footer__item"><a class="p-footer__link" href="https://github.com/ubuntudesign/snapcraft.io/issues/new">Report a bug on this site</a></li>
+                <li class="p-footer__item"><a class="p-footer__link" href="https://github.com/canonical-websites/snapcraft.io/issues/new">Report a bug on this site</a></li>
                 <li class="p-footer__item"><a class="p-footer__link" href="http://status.snapcraft.io/">Service status</a></li>
             </ul>
             <span class="u-off-screen">


### PR DESCRIPTION
Simple Vanilla footer.

Doesn't include social icons as there is currently no pattern to do them without additional custom styles.

Fixes #16 

<img width="1037" alt="screen shot 2017-09-06 at 17 29 04" src="https://user-images.githubusercontent.com/83575/30120372-eff7272e-9328-11e7-9c4a-ed27948b9760.png">
