### PR TITLE
Added large variant for media object pattern for snap details

### DIFF
--- a/static/sass/_patterns_media-object--large.scss
+++ b/static/sass/_patterns_media-object--large.scss
@@ -1,0 +1,12 @@
+@mixin p-media-object--large {
+  .p-media-object__image--large {
+    @extend .p-media-object__image;
+    flex-shrink: 0;
+    height: 6rem;
+    width: 6rem;
+  }
+
+  .p-media-object__content--large {
+    margin-top: 1rem;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -7,6 +7,7 @@
 @include vf-p-grid-modifications;
 @include vf-p-buttons;
 @include vf-p-strip;
+@include vf-p-media-object;
 @include vf-p-muted-heading;
 @include vf-p-navigation;
 @include vf-p-notification;
@@ -20,3 +21,6 @@
 
 @import 'patterns_social-icons';
 @include p-social-icons;
+
+@import 'patterns_media-object--large';
+@include p-media-object--large;

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -5,22 +5,24 @@
 {% block content %}
   <div class="p-strip is-shallow is-bordered">
     <div class="row">
-      <div class="col-2">
-        {% if icon_url %}
-          <img src="{{ icon_url }}" alt="{{ snap_title }} snap" />
-        {% else %}
-          <img src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="" />
-        {% endif %}
-      </div>
-      <div class="col-10">
-        <h1>{{ snap_title }}</h1>
-        <p>{{ publisher }}</p>
+      <div class="col-12">
+        <div class="p-media-object u-no-margin--bottom">
+          {% if icon_url %}
+            <img class="p-media-object__image--large" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
+          {% else %}
+            <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="" />
+          {% endif %}
+          <div class="p-media-object__details">
+            <h1>{{ snap_title }}</h1>
+            <p class="p-media-object__content--large">{{ publisher }}</p>
 
-        {% if is_linux %}
-          <p>
-            <a class="p-button--positive" href="snap://{{ package_name }}">Install</a>
-          </p>
-        {% endif %}
+            {% if is_linux %}
+            <p class="p-media-object__content--large">
+              <a class="p-button--positive" href="snap://{{ package_name }}">Install</a>
+            </p>
+            {% endif %}
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Added variant classes to current Vanilla Media Object pattern according to snap details page design.

This includes `--large` variant of media image and `--large` variant of media content (for correct spacing).

Large screen:
<img width="673" alt="screen shot 2017-09-13 at 15 07 43" src="https://user-images.githubusercontent.com/83575/30379085-a385bad2-9895-11e7-83a9-60b470914f5c.png">

Small screen:
<img width="416" alt="screen shot 2017-09-13 at 15 07 59" src="https://user-images.githubusercontent.com/83575/30379084-a384c474-9895-11e7-957a-89b2f02e67a8.png">

Fixes #43 

QA:
- ./run serve
- Go to any snap details page
- Snap details (icon, title, etc) should use modified Vanilla media pattern