### PR TITLE
Table key value pattern proposal

### DIFF
--- a/static/sass/_patterns_table-key-value.scss
+++ b/static/sass/_patterns_table-key-value.scss
@@ -14,5 +14,9 @@
     tr {
       border-bottom-style: dotted;
     }
+
+    tr:last-child {
+      border-bottom: 0;
+    }
   }
 }

--- a/static/sass/_patterns_table-key-value.scss
+++ b/static/sass/_patterns_table-key-value.scss
@@ -1,0 +1,18 @@
+@mixin vf-p-table-key-value {
+  .p-table-key-value {
+    th,
+    td {
+      padding: $sp-x-small $sp-small;
+    }
+
+    th {
+      color: $color-mid-dark;
+      font-weight: 300;
+      text-align: right;
+    }
+
+    tr {
+      border-bottom-style: dotted;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -24,3 +24,6 @@
 
 @import 'patterns_media-object--large';
 @include p-media-object--large;
+
+@import 'patterns_table-key-value';
+@include vf-p-table-key-value;

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -36,8 +36,8 @@
         {% if support_url %}<p><a href="{{ support_url }}">Developer website</a></p>{% endif %}
       </div>
       <div class="col-4">
-        <table>
-          <tr><th>Version</th><td>{{ version }}</td></tr>
+        <table class="p-table-key-value">
+          <tr><th width="100">Version</th><td>{{ version }}</td></tr>
           <tr><th>Size</th><td>{{ filesize }}</td></tr>
         </table>
       </div>


### PR DESCRIPTION
Added new key-value table pattern.

## QA
- ./run
- Go to any snap page
- Snap details table should have new style

<img width="1025" alt="screen shot 2017-09-19 at 11 22 45" src="https://user-images.githubusercontent.com/83575/30585517-6ba16732-9d2d-11e7-9aa7-0a8354532dfe.png">

## NOTE

As discussed, implemented a design with borders between the rows (but no border at the bottom of the table).