### PR TITLE
Expose geodata to the template

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,7 +74,7 @@ def snap_details(snap_name):
     some of the data through to the snap-details.html template,
     with appropriate sanitation.
     """
-    today = datetime.date.today()
+    today = datetime.datetime.utcnow().date()
     month_ago = today - relativedelta.relativedelta(months=1)
 
     details_response = _get_from_cache(

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -3,6 +3,17 @@
 {% block title %}{{ snap_title }} snap details{% endblock %}
 
 {% block content %}
+  <!-- Illustration of country data -->
+<!--
+  <table>
+    <tbody>
+      {% for country, percent in user_percentage_by_country.items() %}
+        <tr><th>{{ country }}</th><td>{{ percent }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+-->
+
   <div class="p-strip is-shallow is-bordered">
     <div class="row">
       <div class="col-12">


### PR DESCRIPTION
This makes use of the public geodata API that @cprov built.

At present I'm requesting a month of historical data about the percentage of users of a specific snap in each country.

The API returns the data broken down into days, so I am averaging all the days of data returned over the last month to return a single figure. This should hopefully help to avoid anomalous activity that might have happened e.g. in the last 24 hours.

Fixes #52 

QA
--

``` bash
./run
```

Go to a snap page, e.g. <http://0.0.0.0:8022/lxd/>, and view source. You should see the geodata precentages pretty clearly in the source code.