### PR TITLE
Updated Vanilla to 1.5.2 (including white heading)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "author": "Canonical webteam",
   "devDependencies": {
     "autoprefixer": "^7.1.3",
-    "postcss-cli": "^4.1.0",
     "node-sass": "^4.5.3",
+    "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",
-    "vanilla-framework": "1.5.1",
+    "vanilla-framework": "1.5.2",
     "watch-cli": "^0.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2358,9 +2358,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.5.1.tgz#da3a3da7ca170cb444dae54fcc660b2fc305ce7c"
+vanilla-framework@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.5.2.tgz#8cc4d064c592d8072068220e8f419ccda1e00b17"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Updated Vanilla to 1.5.2 (that includes white heading).

Fixes #40 

## QA

- ./run
- Go to snap details page
- Heading should be white