### PR TITLE
Updated footer styles

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -15,6 +15,7 @@
 @include vf-u-floats;
 @include vf-u-off-screen;
 @include vf-u-margin-collapse;
+@include vf-u-padding-collapse;
 
 @import 'patterns_inline-list--compact';
 @include p-inline-list--compact;

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -24,39 +24,23 @@
 
     {% block content %}{% endblock %}
 
-    <footer class="p-footer u-no-margin--top">
-      <div class="row">
-        <div class="col-9">
-          &copy; 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
-          <nav>
-            <ul class="p-footer__links">
-                <li class="p-footer__item"><a class="p-footer__link" href="http://www.ubuntu.com/legal">Legal information</a></li>
-                <li class="p-footer__item"><a class="p-footer__link" href="https://github.com/canonical-websites/snapcraft.io/issues/new">Report a bug on this site</a></li>
-                <li class="p-footer__item"><a class="p-footer__link" href="http://status.snapcraft.io/">Service status</a></li>
-            </ul>
-            <span class="u-off-screen">
-              <a href="#">Go to the top of the page</a>
-            </span>
-          </nav>
+    <div class="p-strip--light u-no-padding">
+      <footer class="p-footer u-no-margin--top">
+        <div class="row">
+          <div class="col-12">
+            Directory &copy; 2017 Canonical Ltd.
+            <nav class="u-no-margin">
+              <ul class="p-footer__links">
+                  <li class="p-footer__item"><a class="p-footer__link" href="http://www.ubuntu.com/legal">Legal information</a></li>
+                  <li class="p-footer__item"><a class="p-footer__link" href="https://github.com/canonical-websites/snapcraft.io/issues/new">Report a bug about the directory</a></li>
+              </ul>
+              <span class="u-off-screen">
+                <a href="#">Go to the top of the page</a>
+              </span>
+            </nav>
+          </div>
         </div>
-        <div class="col-3">
-          <h3 class="p-muted-heading">Follow us</h3>
-          <ul class="p-inline-list--compact">
-            <li class="p-inline-list__item">
-              <a href="https://twitter.com/snapcraftio" class="p-social-icon--twitter">Share on Twitter</a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="https://plus.google.com/+SnapcraftIo" class="p-social-icon--google">Share on Google plus</a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="https://www.facebook.com/snapcraftio" class="p-social-icon--facebook">Share on Facebook</a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="https://www.youtube.com/snapcraftio" class="p-social-icon--youtube">Share on YouTube</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </footer>
+      </footer>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Implements footer updates as defined in #47

<img width="1059" alt="screen shot 2017-09-19 at 15 41 11" src="https://user-images.githubusercontent.com/83575/30595291-15bf9d42-9d51-11e7-95ed-e5de19bc10a2.png">


Fixes #48 

## QA

- ./run
- open snap details page
- Footer should have updated styles

