### PR TITLE
Added info for non-linux systems

### DIFF
--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -16,11 +16,13 @@
             <h1>{{ snap_title }}</h1>
             <p class="p-media-object__content--large">{{ publisher }}</p>
 
-            {% if is_linux %}
             <p class="p-media-object__content--large">
-              <a class="p-button--positive" href="snap://{{ package_name }}">Install</a>
+              {% if is_linux %}
+                <a class="p-button--positive" href="snap://{{ package_name }}">Install</a>
+              {% else %}
+                This software, and hundreds of others, are available on snap-powered systems like <a class="p-link--external" href="https://www.ubuntu.com/download">Ubuntu</a>.
+              {% endif %}
             </p>
-            {% endif %}
           </div>
         </div>
       </div>

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -31,7 +31,7 @@
               {% if is_linux %}
                 <a class="p-button--positive" href="snap://{{ package_name }}">Install</a>
               {% else %}
-                This software, and hundreds of others, are available on snap-powered systems like <a class="p-link--external" href="https://www.ubuntu.com/download">Ubuntu</a>.
+                You can install this software on a snap-powered system like <a class="p-link--external" href="https://www.ubuntu.com/download">Ubuntu</a>.
               {% endif %}
             </p>
           </div>


### PR DESCRIPTION
Added install info for non-linux systems as described in #45 

Fixes #46

### QA
- ./run
- Go to snap details page on Mac or Windows
- Info text should be displayed with a link to Ubuntu

Alternatively use demo: http://snapcraft-flask-pr-57.run.demo.haus/gnome-calculator/

<img width="672" alt="screen shot 2017-09-21 at 16 04 30" src="https://user-images.githubusercontent.com/83575/30700002-98e88e36-9ee6-11e7-8285-9b1b6631e593.png">
