### PR TITLE
Dockerfile similar to www.ubuntu.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:xenial
+
+# System dependencies
+RUN apt-get update && apt-get install --yes python3-pip
+
+# Python dependencies
+ENV LANG C.UTF-8
+RUN pip3 install --upgrade pip
+RUN pip3 install gunicorn
+
+# Set git commit ID
+ARG commit_id
+ENV COMMIT_ID=$commit_id
+
+# Import code, install code dependencies
+WORKDIR /srv
+ADD . .
+RUN pip3 install -r requirements.txt
+
+# Setup commands to run server
+ENTRYPOINT ["gunicorn", "app:app", "-b"]
+CMD ["0.0.0.0:80"]
+


### PR DESCRIPTION
This is for building production images for deployment on Kubernetes

QA
--

``` bash
./run build  # Build CSS files
docker build --build-arg commit_id=`git rev-parse --short HEAD` -t snapcraft.io .  # Build the image
docker run -ti -p 8077:80 snapcraft.io  # Run the image
```

Visit <http://127.0.0.1:8077/lxd/>, see that the site looks as it should.