### PR TITLE
Move homepage from snapcraft.io-static-pages

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -4,6 +4,10 @@
 # Default config: https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml
 # Example config: https://github.com/sasstools/sass-lint/blob/master/docs/sass-lint.yml
 
+files:
+  ignore:
+    - 'static/sass/index.scss'
+
 rules:
   # Documentation: https://github.com/sasstools/sass-lint/tree/master/docs/rules
 

--- a/app.py
+++ b/app.py
@@ -65,6 +65,11 @@ def page_not_found(error):
     ), 404
 
 
+@app.route('/')
+def homepage():
+    return flask.render_template('index.html')
+
+
 @app.route('/<snap_name>/')
 def snap_details(snap_name):
     """

--- a/static/sass/index.scss
+++ b/static/sass/index.scss
@@ -1,0 +1,3199 @@
+@charset "UTF-8";
+b,
+strong {
+  font-weight: bolder; }
+
+dfn {
+  font-style: italic; }
+
+h1 {
+  font-size: 2em;
+  margin: .67em 0; }
+
+mark {
+  background-color: #f7f7f7;
+  color: #333; }
+
+small {
+  font-size: 80%; }
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline; }
+
+sub {
+  bottom: -.25em; }
+
+sup {
+  top: -.5em; }
+
+img {
+  border-style: none; }
+
+svg:not(:root) {
+  overflow: hidden; }
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em; }
+
+figure {
+  margin: 1em 40px; }
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible; }
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font: inherit;
+  margin: 0; }
+
+optgroup {
+  font-weight: bold; }
+
+button,
+input {
+  overflow: visible; }
+
+button,
+select {
+  text-transform: none; }
+
+button,
+html [type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button; }
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0; }
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText; }
+
+fieldset {
+  border: 1px solid #efefef;
+  margin: 0 2px;
+  padding: .35em .625em .75em; }
+
+legend {
+  box-sizing: border-box;
+  color: inherit;
+  display: table;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal; }
+
+textarea {
+  overflow: auto; }
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box;
+  padding: 0; }
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto; }
+
+[type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px; }
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none; }
+
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: .54; }
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit; }
+
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'],
+.button--primary, .button--secondary {
+  font-smoothing: subpixel-antialiased;
+  font-size: 1em;
+  display: inline-block;
+  width: 100%;
+  margin: 0;
+  padding: 11px 24px;
+  text-align: center;
+  text-decoration: none;
+  border: 0;
+  border-radius: 2px;
+  outline: none;
+  font-weight: 300;
+  cursor: pointer; }
+  button:hover,
+  input[type='button']:hover,
+  input[type='reset']:hover,
+  input[type='submit']:hover,
+  .button--primary:hover, .button--secondary:hover {
+    text-decoration: none; }
+  @media only screen and (min-width: 768px) {
+    button,
+    input[type='button'],
+    input[type='reset'],
+    input[type='submit'],
+    .button--primary, .button--secondary {
+      width: auto; } }
+
+.clearfix, .hero-row {
+  display: block; }
+  .clearfix:after, .hero-row:after {
+    clear: both;
+    content: '\0020';
+    display: block;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden; }
+
+input[type='text'], input[type='number'], input[type='search'], input[type='password'], input[type='email'], input[type='url'], input[type='tel'], textarea {
+  -webkit-appearance: textfield;
+  border-radius: 2px;
+  border: 1px solid #cdcdcd;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
+  font-size: 16px;
+  margin: 0;
+  outline: none;
+  padding: .6956522em .869565em;
+  vertical-align: baseline;
+  font-weight: 300; }
+  input[type='text']:active, input[type='number']:active, input[type='search']:active, input[type='password']:active, input[type='email']:active, input[type='url']:active, input[type='tel']:active, textarea:active, input[type='text']:focus, input[type='number']:focus, input[type='search']:focus, input[type='password']:focus, input[type='email']:focus, input[type='url']:focus, input[type='tel']:focus, textarea:focus {
+    border-color: #888;
+    outline: none; }
+  input[type='text']::placeholder, input[type='number']::placeholder, input[type='search']::placeholder, input[type='password']::placeholder, input[type='email']::placeholder, input[type='url']::placeholder, input[type='tel']::placeholder, textarea::placeholder {
+    color: contrast-friendly-search-color(#f7f7f7); }
+
+input[type='checkbox'], input[type='radio'] {
+  border-radius: 2px;
+  border: 1px solid #cdcdcd;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
+  height: 14px;
+  padding: 0;
+  vertical-align: middle;
+  width: 14px; }
+
+input[disabled="disabled"][type='checkbox'] + label, input[disabled="disabled"][type='radio'] + label, form input[disabled="disabled"],
+form select[disabled="disabled"],
+form textarea[disabled="disabled"] {
+  opacity: .5;
+  cursor: not-allowed; }
+
+.inner-wrapper {
+  margin: 0 auto;
+  max-width: 1030px; }
+
+[class*='-col'].last-col,
+[class*='-col'] [class*='-col'].last-col {
+  margin-right: 0; }
+
+.one-col, .two-col, .three-col, .four-col, .five-col, .six-col, .seven-col, .eight-col, .nine-col, .ten-col, .eleven-col, .twelve-col {
+  clear: none;
+  margin-bottom: 20px;
+  margin-right: 0;
+  padding: 0;
+  display: inline-block;
+  position: relative;
+  width: 100%; }
+  @media only screen and (min-width: 768px) {
+    .one-col, .two-col, .three-col, .four-col, .five-col, .six-col, .seven-col, .eight-col, .nine-col, .ten-col, .eleven-col, .twelve-col {
+      float: left; } }
+
+.list-ticks, .list {
+  list-style: none;
+  margin-left: 0; }
+  .list-ticks li, .list li {
+    border-bottom: 1px dotted #888;
+    margin-bottom: 0;
+    padding: 10px 0; }
+  .list-ticks li:last-of-type, .list li:last-of-type, .list-ticks .last-item, .list .last-item {
+    border: 0;
+    margin-bottom: 0;
+    padding-bottom: 0; }
+
+.list-ticks li {
+  background-repeat: no-repeat;
+  background-position: 0 1em;
+  padding-left: 25px; }
+
+.box {
+  background: #fff;
+  border: 1px solid #cdcdcd;
+  padding: 1.25em 20px; }
+
+@media only screen and (min-width: 768px) {
+  .equal-height, .equal-height--vertical-divider {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    width: 100%; }
+    .equal-height .equal-height__item, .equal-height--vertical-divider .equal-height__item {
+      display: flex;
+      flex: auto;
+      flex-direction: column; } }
+
+* {
+  font-smoothing: subpixel-antialiased;
+  box-sizing: border-box; }
+
+html {
+  text-size-adjust: 100%;
+  font-size: 100%;
+  overflow-y: scroll; }
+
+a,
+acronym,
+address,
+applet,
+article,
+aside,
+audio,
+b,
+big,
+blockquote,
+body,
+canvas,
+caption,
+center,
+cite,
+code,
+del,
+details,
+dfn,
+div,
+dl,
+em,
+embed,
+figcaption,
+figure,
+footer,
+form,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+header,
+html,
+i,
+iframe,
+img,
+ins,
+kbd,
+label,
+legend,
+li,
+mark,
+menu,
+nav,
+object,
+ol,
+output,
+p,
+pre,
+q,
+ruby,
+s,
+samp,
+section,
+small,
+span,
+strike,
+strong,
+sub,
+summary,
+sup,
+table,
+tbody,
+td,
+tfoot,
+th,
+thead,
+time,
+tr,
+tt,
+u,
+ul,
+var,
+video {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  vertical-align: baseline; }
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block; }
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; }
+
+audio:not([controls]) {
+  display: none;
+  height: 0; }
+
+progress {
+  vertical-align: baseline; }
+
+template,
+[hidden] {
+  display: none; }
+
+a {
+  background-color: transparent;
+  -webkit-text-decoration-skip: objects; }
+
+abbr[title] {
+  border-bottom: 0;
+  text-decoration: underline; }
+
+blockquote,
+q {
+  quotes: none; }
+
+legend {
+  border: 0; }
+
+figure {
+  margin: 0; }
+
+abbr,
+acronym {
+  cursor: help; }
+
+.link-arrow:after {
+  content: '\0000a0›'; }
+
+nav ul li h2 a:after {
+  content: '\0000a0›'; }
+
+nav ul li a:after,
+ul li p a:after {
+  content: ''; }
+
+img {
+  border: 0;
+  height: auto;
+  max-width: 100%; }
+  img .left {
+    margin-right: 20px; }
+  img .right {
+    margin-left: 20px; }
+
+.middle img {
+  vertical-align: middle;
+  margin-top: 4em; }
+
+ins {
+  background: #fffbeb;
+  text-decoration: none; }
+
+.left {
+  float: left; }
+
+.right {
+  float: right; }
+
+.no-border {
+  border: 0; }
+
+.link-top {
+  font-size: .875em;
+  clear: both;
+  margin-bottom: 40px;
+  margin-top: -40px; }
+  .link-top a {
+    background: #fff;
+    margin-right: 10px;
+    margin-top: -35px;
+    padding: 5px;
+    float: right; }
+
+.caps {
+  text-transform: uppercase; }
+
+.touch-border,
+.touch-bottom {
+  float: left; }
+  @media only screen and (min-width: 768px) {
+    .touch-border,
+    .touch-bottom {
+      margin-bottom: -20px; } }
+  @media only screen and (min-width: 1030px) {
+    .touch-border,
+    .touch-bottom {
+      margin-bottom: -40px; } }
+
+.accessibility-aid,
+.off-left {
+  position: absolute;
+  left: -999em; }
+
+.external {
+  background-size: .7em .7em;
+  padding-right: .9em;
+  background-image: url("https://assets.ubuntu.com/v1/f24a8aa0-external-link-orange.svg");
+  background-position: 100% top;
+  background-repeat: no-repeat; }
+
+.no-svg .external {
+  background-image: url("https://assets.ubuntu.com/v1/f24a8aa0-external-link-orange.svg"); }
+
+.text-center,
+.align-center {
+  text-align: center; }
+
+.no-margin-bottom {
+  margin-bottom: 0; }
+
+.no-padding-bottom {
+  padding-bottom: 0; }
+
+.pull-bottom-right {
+  float: right;
+  margin-right: -10px; }
+
+@media only screen and (min-width: 768px) {
+  .pull-bottom-right {
+    margin-right: -40px;
+    margin-bottom: -40px; } }
+
+@media only screen and (min-width: 1030px) {
+  .pull-bottom-right {
+    margin-right: -40px;
+    margin-bottom: -60px; } }
+
+.pull-bottom-left {
+  float: left;
+  margin-left: -10px; }
+
+@media only screen and (min-width: 768px) {
+  .pull-bottom-left {
+    margin-left: -40px;
+    margin-bottom: -40px; } }
+
+@media only screen and (min-width: 1030px) {
+  .pull-bottom-left {
+    margin-left: -40px;
+    margin-bottom: -60px; } }
+
+@media only screen and (max-width: 767px) {
+  .priority-0,
+  .not-for-small {
+    display: none; } }
+
+@media only screen and (min-width: 768px) {
+  .for-mobile,
+  .for-small {
+    display: none; } }
+
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden; }
+  .video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%; }
+  .video-container + .video-title {
+    margin-top: 20px; }
+
+.pull-right {
+  float: right;
+  margin-right: -40px; }
+  @media only screen and (max-width: 768px) {
+    .pull-right {
+      margin-bottom: 20px; } }
+
+.pull-left {
+  margin-left: -40px; }
+
+.for-tablet,
+.for-medium {
+  display: none; }
+  @media only screen and (min-width: 768px) {
+    .for-tablet,
+    .for-medium {
+      display: block; } }
+
+@media only screen and (min-width: 768px) and (max-width: 1030px) {
+  .med-six-col .three-col {
+    width: 48.93617%; }
+  .med-six-col .three-col:nth-of-type(2n) {
+    margin-right: 0; } }
+
+blockquote {
+  margin: 0; }
+  blockquote > p {
+    font-size: 1em;
+    margin: 0 0 .4em; }
+  blockquote small {
+    font-size: .8125em;
+    line-height: 1.4; }
+
+.pull-quote {
+  text-indent: 0; }
+  .pull-quote p {
+    font-size: 1.5em;
+    line-height: 1.3;
+    margin-left: .4em;
+    padding-left: 10px;
+    padding-right: 10px;
+    text-indent: -.4em; }
+    .pull-quote p span {
+      color: #f7f7f7;
+      font-weight: bold;
+      left: -5px;
+      line-height: 0;
+      position: relative; }
+      .pull-quote p span:last-of-type {
+        left: 5px; }
+    .pull-quote p cite {
+      display: block;
+      font-size: .75em;
+      font-weight: 300;
+      margin: 10px 0 0;
+      text-indent: 0; }
+  @media only screen and (min-width: 768px) {
+    .pull-quote p {
+      padding-left: 0;
+      padding-right: 0;
+      text-indent: -.7em; }
+      .pull-quote p span {
+        top: 5px;
+        font-size: 1.391304348em; }
+      .pull-quote p cite {
+        margin-left: 0;
+        text-indent: 0; } }
+  @media only screen and (min-width: 1030px) {
+    .pull-quote p span {
+      top: 10px; } }
+
+.row-quote {
+  border-radius: 0; }
+  .row-quote blockquote {
+    border-radius: 4px;
+    margin: 0;
+    padding: 0; }
+    .row-quote blockquote p {
+      color: #333;
+      line-height: 1.3;
+      margin-bottom: .75em;
+      padding-left: 10px;
+      padding-right: 10px;
+      text-indent: 0; }
+    .row-quote blockquote span {
+      color: #f7f7f7;
+      font-weight: bold;
+      left: -5px;
+      line-height: 0;
+      position: relative; }
+      .row-quote blockquote span + span {
+        left: 5px; }
+    .row-quote blockquote cite {
+      color: #333;
+      font-size: .75em;
+      font-style: normal;
+      margin-bottom: 0;
+      text-indent: 0; }
+  @media only screen and (min-width: 768px) {
+    .row-quote {
+      text-indent: -.4em; }
+      .row-quote blockquote {
+        text-indent: -7px; }
+        .row-quote blockquote p {
+          font-size: 1.5em;
+          padding-left: 0;
+          padding-right: 0;
+          text-indent: -.4em; }
+        .row-quote blockquote span {
+          top: 5px;
+          font-size: 1.391304348em; }
+        .row-quote blockquote cite {
+          margin-left: 0;
+          text-indent: 0; } }
+  @media only screen and (min-width: 1030px) {
+    .row-quote blockquote {
+      padding: 0 80px 20px;
+      text-indent: -10px; }
+      .row-quote blockquote p span {
+        top: 10px; } }
+
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'],
+.button--primary {
+  color: #fff;
+  background-color: #fff; }
+  button:hover,
+  input[type='button']:hover,
+  input[type='reset']:hover,
+  input[type='submit']:hover,
+  .button--primary:hover {
+    background-color: #efefef; }
+  button .external,
+  input[type='button'] .external,
+  input[type='reset'] .external,
+  input[type='submit'] .external,
+  .button--primary .external {
+    background-image: url("https://assets.ubuntu.com/v1/484aba04-external-link-white.svg"); }
+
+.button--secondary {
+  color: #fff;
+  background-color: #fff;
+  border: 1px solid #cdcdcd; }
+  .button--secondary:hover {
+    background-color: #efefef; }
+
+@media only screen and (min-width: 620px) {
+  .nav-secondary {
+    border: 1px solid #d2d2d2;
+    border-top: 0; } }
+
+.nav-secondary .breadcrumb {
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 2px;
+  padding-bottom: 3px; }
+  @media only screen and (min-width: 620px) {
+    .nav-secondary .breadcrumb {
+      float: left;
+      margin-left: 4px; } }
+  .nav-secondary .breadcrumb li {
+    color: #fff;
+    display: inline-block;
+    margin: 0;
+    width: 100%; }
+    @media only screen and (min-width: 620px) {
+      .nav-secondary .breadcrumb li {
+        display: inline-block;
+        width: auto; } }
+    .nav-secondary .breadcrumb li:first-of-type {
+      border-bottom: 1px solid #d2d2d2; }
+      @media only screen and (min-width: 620px) {
+        .nav-secondary .breadcrumb li:first-of-type {
+          border-bottom: 0; } }
+    .nav-secondary .breadcrumb li a {
+      color: #888;
+      font-size: 1em;
+      display: inline-block;
+      width: 100%;
+      margin-right: 0;
+      padding: 8px 10px;
+      text-decoration: none; }
+      @media only screen and (min-width: 620px) {
+        .nav-secondary .breadcrumb li a {
+          font-size: .875em; } }
+    @media only screen and (min-width: 620px) {
+      .nav-secondary .breadcrumb li .breadcrumb-link,
+      .nav-secondary .breadcrumb li .breadcrumb-link--second-level,
+      .nav-secondary .breadcrumb li .active {
+        display: inline-block;
+        float: none;
+        width: auto; } }
+    .nav-secondary .breadcrumb li .breadcrumb-link:after,
+    .nav-secondary .breadcrumb li .breadcrumb-link--second-level:after {
+      content: '\203A';
+      display: inline-block;
+      height: 5px;
+      margin-left: 8px;
+      position: absolute;
+      width: 5px; }
+
+.nav-secondary .second-level-nav,
+.nav-secondary .third-level-nav {
+  display: none;
+  overflow: hidden;
+  width: 100%;
+  margin: 0;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #d2d2d2; }
+  @media only screen and (min-width: 620px) {
+    .nav-secondary .second-level-nav,
+    .nav-secondary .third-level-nav {
+      display: inline;
+      float: none;
+      margin-bottom: 0;
+      padding: 0;
+      width: auto;
+      border-bottom: 0; } }
+  .nav-secondary .second-level-nav li,
+  .nav-secondary .third-level-nav li {
+    margin: 0; }
+    @media only screen and (min-width: 620px) {
+      .nav-secondary .second-level-nav li,
+      .nav-secondary .third-level-nav li {
+        float: none;
+        width: auto; } }
+    .nav-secondary .second-level-nav li a,
+    .nav-secondary .third-level-nav li a {
+      font-size: .875em;
+      display: block;
+      width: 100%;
+      height: 100%;
+      padding: 10px;
+      color: #333; }
+      @media only screen and (max-width: 620px) {
+        .nav-secondary .second-level-nav li a.active,
+        .nav-secondary .third-level-nav li a.active {
+          font-weight: 500; } }
+      @media only screen and (min-width: 620px) {
+        .nav-secondary .second-level-nav li a,
+        .nav-secondary .third-level-nav li a {
+          padding: 8px 10px 0; }
+          .nav-secondary .second-level-nav li a.active,
+          .nav-secondary .third-level-nav li a.active {
+            color: #007aa6; } }
+
+@media only screen and (min-width: 620px) {
+  .nav-secondary .second-level-nav li {
+    width: auto; }
+    .nav-secondary .second-level-nav li .active,
+    .nav-secondary .second-level-nav li .breadcrumb-link--second-level {
+      color: #888; }
+    .nav-secondary .second-level-nav li .third-level-nav li a {
+      color: #333; }
+    .nav-secondary .second-level-nav li .third-level-nav li a:hover {
+      color: #007aa6; }
+    .nav-secondary .second-level-nav li .third-level-nav li .active {
+      color: #007aa6;
+      float: none; }
+      .nav-secondary .second-level-nav li .third-level-nav li .active:after {
+        content: ''; } }
+
+.third-level-nav li a:hover {
+  color: #007aa6; }
+
+.third-level-nav li .active {
+  color: #007aa6;
+  float: none; }
+
+@media only screen and (max-width: 619px) {
+  #breadcrumbs:hover .second-level-nav,
+  #breadcrumbs:hover .third-level-nav,
+  #breadcrumbs:hover .active {
+    border: 0;
+    display: block;
+    overflow: visible;
+    float: left;
+    width: 100%;
+    position: relative;
+    clear: both; }
+  #breadcrumbs:hover li {
+    border: 0;
+    float: left; }
+  #breadcrumbs:hover .second-level-nav {
+    border-top: 1px solid #d2d2d2; }
+    #breadcrumbs:hover .second-level-nav li {
+      float: left; }
+  #breadcrumbs:hover .third-level-nav {
+    border-bottom: 1px solid #d2d2d2;
+    padding-top: 0; }
+    #breadcrumbs:hover .third-level-nav li {
+      width: 50%;
+      display: block;
+      padding-left: 10px; } }
+
+code,
+samp,
+kbd {
+  font-family: 'Ubuntu Mono', 'Consolas', 'Monaco', 'Lucida Console', 'Courier New', Courier, monospace;
+  text-align: left; }
+
+pre,
+code {
+  text-align: left;
+  white-space: pre-line;
+  word-spacing: normal;
+  word-wrap: break-word;
+  tab-size: 4;
+  hyphens: none;
+  direction: ltr; }
+
+.code-block {
+  overflow: auto;
+  margin: .5em 0;
+  padding: 1em;
+  border: 1px solid #cdcdcd;
+  border-radius: .5em; }
+  .code-block .code-block__line {
+    float: left;
+    clear: both;
+    margin: 0; }
+  .code-block.code-block--terminal {
+    color: #fff;
+    border: 0;
+    background-color: #333; }
+  .code-block.code-block--numbering {
+    counter-reset: line-numbering; }
+    .code-block.code-block--numbering .code-block__line::before {
+      width: 1.5em;
+      padding-right: 1em;
+      /* space after numbers */
+      content: counter(line-numbering);
+      counter-increment: line-numbering;
+      user-select: none;
+      text-align: right;
+      pointer-events: none;
+      opacity: .5; }
+
+.code-snippet {
+  position: relative;
+  overflow: hidden;
+  transition: all .2s;
+  border: 1px solid #cdcdcd;
+  border-radius: 4px;
+  background-color: #fff; }
+  .code-snippet .code-snippet__input {
+    font-family: 'Ubuntu Mono', 'Consolas', 'Monaco', 'Lucida Console', 'Courier New', Courier, monospace;
+    font-size: 1em;
+    font-weight: 300;
+    width: 100%;
+    padding: .7em 1em;
+    color: #333;
+    border: 0;
+    background: transparent; }
+  .code-snippet .code-snippet__copy-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: block;
+    width: 50px;
+    height: 100%;
+    text-indent: -9999px;
+    border-left: 1px solid #cdcdcd;
+    background-color: #fff;
+    background-image: url("https://assets.ubuntu.com/v1/994e60f9-get-link-url_16.svg");
+    background-repeat: no-repeat;
+    background-position: center; }
+  .code-snippet.code-snippet--terminal {
+    color: #fff;
+    border-color: #333;
+    background-color: #333; }
+    .code-snippet.code-snippet--terminal .code-snippet__input {
+      color: #fff; }
+    .code-snippet.code-snippet--terminal .code-snippet__copy-button {
+      border-left: 0; }
+
+label {
+  cursor: pointer;
+  display: block;
+  margin-bottom: 4px; }
+  label.has-error {
+    color: #df382c; }
+  label.has-warning {
+    color: #eca918; }
+  label.has-success {
+    color: #38b44a; }
+  label.has-information {
+    color: #19b6ee; }
+
+input[type='reset'] {
+  display: none; }
+
+input[type='search'] {
+  -webkit-appearance: none;
+  border-radius: 0; }
+
+input[type='checkbox'] + label, input[type='radio'] + label {
+  display: inline;
+  margin-left: 5px;
+  vertical-align: middle;
+  width: auto; }
+
+input.has-error {
+  border: 1px solid #df382c; }
+  input.has-error:focus {
+    border: 1px solid #df382c; }
+
+input.has-warning {
+  border: 1px solid #eca918; }
+  input.has-warning:focus {
+    border: 1px solid #eca918; }
+
+input.has-success {
+  border: 1px solid #38b44a; }
+  input.has-success:focus {
+    border: 1px solid #38b44a; }
+
+input.has-information {
+  border: 1px solid #19b6ee; }
+  input.has-information:focus {
+    border: 1px solid #19b6ee; }
+
+form ul {
+  margin-left: 0;
+  list-style: none; }
+
+textarea {
+  overflow: auto;
+  vertical-align: top; }
+  textarea[readonly='readonly'] {
+    color: #888;
+    cursor: default; }
+    textarea[readonly='readonly']:active, textarea[readonly='readonly']:focus {
+      border-color: #888;
+      outline: none; }
+
+fieldset {
+  background-color: #f7f7f7;
+  background-position: -15px -15px;
+  background-repeat: no-repeat;
+  border-radius: 4px;
+  border: 0;
+  margin-bottom: 8px;
+  padding: 15px 20px; }
+  @media only screen and (min-width: 1030px) {
+    fieldset {
+      padding: 15px 20px; } }
+  fieldset h3 {
+    border-bottom: 1px dotted #cdcdcd;
+    margin-bottom: 9px;
+    padding-bottom: 10px; }
+
+form input,
+form select,
+form textarea {
+  width: 100%; }
+
+@media only screen and (min-width: 768px) {
+  .one-col {
+    float: left;
+    width: 6.40351%;
+    margin-right: 2.10526%; }
+    .one-col .one-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .two-col {
+    float: left;
+    width: 14.91228%;
+    margin-right: 2.10526%; }
+    .two-col .one-col {
+      float: left;
+      width: 43.81443%;
+      margin-right: 12.37113%; }
+    .two-col .two-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .three-col {
+    float: left;
+    width: 23.42105%;
+    margin-right: 2.10526%; }
+    .three-col .one-col {
+      float: left;
+      width: 27.83505%;
+      margin-right: 8.24742%; }
+    .three-col .two-col {
+      float: left;
+      width: 63.91753%;
+      margin-right: 8.24742%; }
+    .three-col .three-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .four-col {
+    float: left;
+    width: 31.92982%;
+    margin-right: 2.10526%; }
+    .four-col .one-col {
+      float: left;
+      width: 20.36082%;
+      margin-right: 6.18557%; }
+    .four-col .two-col {
+      float: left;
+      width: 46.90722%;
+      margin-right: 6.18557%; }
+    .four-col .three-col {
+      float: left;
+      width: 73.45361%;
+      margin-right: 6.18557%; }
+    .four-col .four-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .five-col {
+    float: left;
+    width: 40.4386%;
+    margin-right: 2.10526%; }
+    .five-col .one-col {
+      float: left;
+      width: 16.04124%;
+      margin-right: 4.94845%; }
+    .five-col .two-col {
+      float: left;
+      width: 37.03093%;
+      margin-right: 4.94845%; }
+    .five-col .three-col {
+      float: left;
+      width: 58.02062%;
+      margin-right: 4.94845%; }
+    .five-col .four-col {
+      float: left;
+      width: 79.01031%;
+      margin-right: 4.94845%; }
+    .five-col .five-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .six-col {
+    float: left;
+    width: 48.94737%;
+    margin-right: 2.10526%; }
+    .six-col .one-col {
+      float: left;
+      width: 13.23024%;
+      margin-right: 4.12371%; }
+    .six-col .two-col {
+      float: left;
+      width: 30.58419%;
+      margin-right: 4.12371%; }
+    .six-col .three-col {
+      float: left;
+      width: 47.93814%;
+      margin-right: 4.12371%; }
+    .six-col .four-col {
+      float: left;
+      width: 65.2921%;
+      margin-right: 4.12371%; }
+    .six-col .five-col {
+      float: left;
+      width: 82.64605%;
+      margin-right: 4.12371%; }
+    .six-col .six-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .seven-col {
+    float: left;
+    width: 57.45614%;
+    margin-right: 2.10526%; }
+    .seven-col .one-col {
+      float: left;
+      width: 11.25605%;
+      margin-right: 3.53461%; }
+    .seven-col .two-col {
+      float: left;
+      width: 26.04671%;
+      margin-right: 3.53461%; }
+    .seven-col .three-col {
+      float: left;
+      width: 40.83737%;
+      margin-right: 3.53461%; }
+    .seven-col .four-col {
+      float: left;
+      width: 55.62802%;
+      margin-right: 3.53461%; }
+    .seven-col .five-col {
+      float: left;
+      width: 70.41868%;
+      margin-right: 3.53461%; }
+    .seven-col .six-col {
+      float: left;
+      width: 85.20934%;
+      margin-right: 3.53461%; }
+    .seven-col .seven-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .eight-col {
+    float: left;
+    width: 65.96491%;
+    margin-right: 2.10526%; }
+    .eight-col .one-col {
+      float: left;
+      width: 9.79381%;
+      margin-right: 3.09278%; }
+    .eight-col .two-col {
+      float: left;
+      width: 22.68041%;
+      margin-right: 3.09278%; }
+    .eight-col .three-col {
+      float: left;
+      width: 35.56701%;
+      margin-right: 3.09278%; }
+    .eight-col .four-col {
+      float: left;
+      width: 48.45361%;
+      margin-right: 3.09278%; }
+    .eight-col .five-col {
+      float: left;
+      width: 61.34021%;
+      margin-right: 3.09278%; }
+    .eight-col .six-col {
+      float: left;
+      width: 74.2268%;
+      margin-right: 3.09278%; }
+    .eight-col .seven-col {
+      float: left;
+      width: 87.1134%;
+      margin-right: 3.09278%; }
+    .eight-col .eight-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .nine-col {
+    float: left;
+    width: 74.47368%;
+    margin-right: 2.10526%; }
+    .nine-col .one-col {
+      float: left;
+      width: 8.66743%;
+      margin-right: 2.74914%; }
+    .nine-col .two-col {
+      float: left;
+      width: 20.084%;
+      margin-right: 2.74914%; }
+    .nine-col .three-col {
+      float: left;
+      width: 31.50057%;
+      margin-right: 2.74914%; }
+    .nine-col .four-col {
+      float: left;
+      width: 42.91714%;
+      margin-right: 2.74914%; }
+    .nine-col .five-col {
+      float: left;
+      width: 54.33372%;
+      margin-right: 2.74914%; }
+    .nine-col .six-col {
+      float: left;
+      width: 65.75029%;
+      margin-right: 2.74914%; }
+    .nine-col .seven-col {
+      float: left;
+      width: 77.16686%;
+      margin-right: 2.74914%; }
+    .nine-col .eight-col {
+      float: left;
+      width: 88.58343%;
+      margin-right: 2.74914%; }
+    .nine-col .nine-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .ten-col {
+    float: left;
+    width: 82.98246%;
+    margin-right: 2.10526%; }
+    .ten-col .one-col {
+      float: left;
+      width: 7.7732%;
+      margin-right: 2.47423%; }
+    .ten-col .two-col {
+      float: left;
+      width: 18.02062%;
+      margin-right: 2.47423%; }
+    .ten-col .three-col {
+      float: left;
+      width: 28.26804%;
+      margin-right: 2.47423%; }
+    .ten-col .four-col {
+      float: left;
+      width: 38.51546%;
+      margin-right: 2.47423%; }
+    .ten-col .five-col {
+      float: left;
+      width: 48.76289%;
+      margin-right: 2.47423%; }
+    .ten-col .six-col {
+      float: left;
+      width: 59.01031%;
+      margin-right: 2.47423%; }
+    .ten-col .seven-col {
+      float: left;
+      width: 69.25773%;
+      margin-right: 2.47423%; }
+    .ten-col .eight-col {
+      float: left;
+      width: 79.50515%;
+      margin-right: 2.47423%; }
+    .ten-col .nine-col {
+      float: left;
+      width: 89.75258%;
+      margin-right: 2.47423%; }
+    .ten-col .ten-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .eleven-col {
+    float: left;
+    width: 91.49123%;
+    margin-right: 2.10526%; }
+    .eleven-col .one-col {
+      float: left;
+      width: 7.04609%;
+      margin-right: 2.2493%; }
+    .eleven-col .two-col {
+      float: left;
+      width: 16.34148%;
+      margin-right: 2.2493%; }
+    .eleven-col .three-col {
+      float: left;
+      width: 25.63687%;
+      margin-right: 2.2493%; }
+    .eleven-col .four-col {
+      float: left;
+      width: 34.93227%;
+      margin-right: 2.2493%; }
+    .eleven-col .five-col {
+      float: left;
+      width: 44.22766%;
+      margin-right: 2.2493%; }
+    .eleven-col .six-col {
+      float: left;
+      width: 53.52305%;
+      margin-right: 2.2493%; }
+    .eleven-col .seven-col {
+      float: left;
+      width: 62.81844%;
+      margin-right: 2.2493%; }
+    .eleven-col .eight-col {
+      float: left;
+      width: 72.11383%;
+      margin-right: 2.2493%; }
+    .eleven-col .nine-col {
+      float: left;
+      width: 81.40922%;
+      margin-right: 2.2493%; }
+    .eleven-col .ten-col {
+      float: left;
+      width: 90.70461%;
+      margin-right: 2.2493%; }
+    .eleven-col .eleven-col {
+      width: 100%;
+      margin-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .prepend-one {
+    margin-left: 8.50877%; }
+  .prepend-two {
+    margin-left: 17.01754%; }
+  .prepend-three {
+    margin-left: 25.52632%; }
+  .prepend-four {
+    margin-left: 34.03509%; }
+  .prepend-five {
+    margin-left: 42.54386%; }
+  .prepend-six {
+    margin-left: 51.05263%; }
+  .prepend-seven {
+    margin-left: 59.5614%; }
+  .prepend-eight {
+    margin-left: 68.07018%; }
+  .prepend-nine {
+    margin-left: 76.57895%; }
+  .prepend-ten {
+    margin-left: 85.08772%; }
+  .prepend-eleven {
+    margin-left: 93.59649%; } }
+
+@media only screen and (min-width: 768px) {
+  .append-one {
+    margin-right: 8.50877%; }
+  .append-two {
+    margin-right: 17.01754%; }
+  .append-three {
+    margin-right: 25.52632%; }
+  .append-four {
+    margin-right: 34.03509%; }
+  .append-five {
+    margin-right: 42.54386%; }
+  .append-six {
+    margin-right: 51.05263%; }
+  .append-seven {
+    margin-right: 59.5614%; }
+  .append-eight {
+    margin-right: 68.07018%; }
+  .append-nine {
+    margin-right: 76.57895%; }
+  .append-ten {
+    margin-right: 85.08772%; }
+  .append-eleven {
+    margin-right: 93.59649%; } }
+
+@media only screen and (min-width: 768px) {
+  .push-one {
+    float: left;
+    position: relative;
+    margin: 0 -8.50877% 0 8.50877%; }
+  .push-two {
+    float: left;
+    position: relative;
+    margin: 0 -19.12281% 0 19.12281%; }
+  .push-three {
+    float: left;
+    position: relative;
+    margin: 0 -27.63158% 0 27.63158%; }
+  .push-four {
+    float: left;
+    position: relative;
+    margin: 0 -36.14035% 0 36.14035%; }
+  .push-five {
+    float: left;
+    position: relative;
+    margin: 0 -44.64912% 0 44.64912%; }
+  .push-six {
+    float: left;
+    position: relative;
+    margin: 0 -53.15789% 0 53.15789%; }
+  .push-seven {
+    float: left;
+    position: relative;
+    margin: 0 -61.66667% 0 61.66667%; }
+  .push-eight {
+    float: left;
+    position: relative;
+    margin: 0 -70.17544% 0 70.17544%; }
+  .push-nine {
+    float: left;
+    position: relative;
+    margin: 0 -78.68421% 0 78.68421%; }
+  .push-ten {
+    float: left;
+    position: relative;
+    margin: 0 -87.19298% 0 87.19298%; }
+  .push-eleven {
+    float: left;
+    position: relative;
+    margin: 0 -95.70175% 0 95.70175%; } }
+
+@media only screen and (min-width: 768px) {
+  .pull-one {
+    float: left;
+    position: relative;
+    margin-left: -6.40351%; }
+  .pull-two {
+    float: left;
+    position: relative;
+    margin-left: 17.01754%; }
+  .pull-three {
+    float: left;
+    position: relative;
+    margin-left: 25.52632%; }
+  .pull-four {
+    float: left;
+    position: relative;
+    margin-left: 34.03509%; }
+  .pull-five {
+    float: left;
+    position: relative;
+    margin-left: 42.54386%; }
+  .pull-six {
+    float: left;
+    position: relative;
+    margin-left: 51.05263%; }
+  .pull-seven {
+    float: left;
+    position: relative;
+    margin-left: 59.5614%; }
+  .pull-eight {
+    float: left;
+    position: relative;
+    margin-left: 68.07018%; }
+  .pull-nine {
+    float: left;
+    position: relative;
+    margin-left: 76.57895%; }
+  .pull-ten {
+    float: left;
+    position: relative;
+    margin-left: 85.08772%; }
+  .pull-eleven {
+    float: left;
+    position: relative;
+    margin-left: 93.59649%; } }
+
+.banner {
+  background: #f7f7f7;
+  border-bottom: 0;
+  border-top: 0;
+  box-shadow: inset 0 -1px 0 #cccccc;
+  display: block;
+  min-width: 100%;
+  position: relative;
+  width: auto;
+  z-index: 2; }
+  @media only screen and (min-width: 620px) {
+    .banner {
+      border-bottom: 1px solid #cccccc;
+      box-shadow: none; } }
+  .banner .logo {
+    position: relative;
+    display: table;
+    float: left;
+    overflow: hidden;
+    height: 48px;
+    margin: 0 10px;
+    border-left: 0; }
+    @media only screen and (min-width: 620px) {
+      .banner .logo {
+        margin: 0 15px; } }
+    .banner .logo a {
+      display: table-cell;
+      height: 100%;
+      vertical-align: middle;
+      color: #333; }
+      .banner .logo a span {
+        display: inline-block; }
+  .banner h2 {
+    font-size: 1.563em;
+    position: relative;
+    top: 14px;
+    left: 4px;
+    display: block;
+    margin-bottom: 0;
+    text-transform: lowercase; }
+    .banner h2 a,
+    .banner h2 a:link,
+    .banner h2 a:visited {
+      float: left;
+      text-decoration: none;
+      color: #333; }
+  .banner .nav-primary {
+    overflow: hidden;
+    margin: 0 auto;
+    border: 0; }
+    @media only screen and (min-width: 620px) {
+      .banner .nav-primary {
+        max-width: 1030px; } }
+    .banner .nav-primary span {
+      display: none; }
+    .banner .nav-primary ul {
+      display: none;
+      float: left;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      border-top: 1px solid #cccccc;
+      box-shadow: inset 0 -1px 0 #cccccc;
+      background-color: #ebebeb; }
+      @media only screen and (min-width: 620px) {
+        .banner .nav-primary ul {
+          position: static;
+          display: block;
+          width: auto;
+          border-top: 0;
+          background-color: transparent;
+          box-shadow: none; } }
+      .banner .nav-primary ul li {
+        float: left;
+        width: 50%;
+        margin: 0;
+        border-right: 1px solid #cccccc;
+        border-bottom: 1px solid #cccccc;
+        background: transparent; }
+        @media only screen and (min-width: 620px) {
+          .banner .nav-primary ul li {
+            width: auto;
+            border-right: 0;
+            border-bottom: 0;
+            border-left: 1px solid #e3e3e3; }
+            .banner .nav-primary ul li:last-child {
+              border-right: 1px solid #e3e3e3; }
+              .banner .nav-primary ul li:last-child a {
+                border-right: 0; } }
+        @media only screen and (max-width: 620px) {
+          .banner .nav-primary ul li:nth-child(2n+2) {
+            border-right: 0; } }
+        .banner .nav-primary ul li a,
+        .banner .nav-primary ul li a:link,
+        .banner .nav-primary ul li a:visited {
+          font-size: 1em;
+          font-weight: 300;
+          position: relative;
+          display: block;
+          margin-bottom: 0;
+          padding: 8px 10px;
+          text-align: left;
+          text-decoration: none;
+          background-color: #ebebeb;
+          font-smoothing: subpixel-antialiased;
+          color: #333; }
+          @media only screen and (min-width: 620px) {
+            .banner .nav-primary ul li a,
+            .banner .nav-primary ul li a:link,
+            .banner .nav-primary ul li a:visited {
+              font-size: .875em;
+              padding: 14px 14px 13px;
+              text-align: center;
+              border-left: 1px solid white;
+              background-color: transparent;
+              color: #333; } }
+          .banner .nav-primary ul li a:hover,
+          .banner .nav-primary ul li a:link:hover,
+          .banner .nav-primary ul li a:visited:hover {
+            background: #f2f2f2; }
+            @media only screen and (min-width: 620px) {
+              .banner .nav-primary ul li a:hover,
+              .banner .nav-primary ul li a:link:hover,
+              .banner .nav-primary ul li a:visited:hover {
+                background-color: white; } }
+          .banner .nav-primary ul li a.active,
+          .banner .nav-primary ul li a:link.active,
+          .banner .nav-primary ul li a:visited.active {
+            background-color: #ddd; }
+            @media only screen and (min-width: 620px) {
+              .banner .nav-primary ul li a.active,
+              .banner .nav-primary ul li a:link.active,
+              .banner .nav-primary ul li a:visited.active {
+                background-color: #e3e3e3;
+                border-left: 0; } }
+  .banner .nav-toggle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: block;
+    width: 48px;
+    height: 48px;
+    cursor: pointer;
+    text-indent: -99999px;
+    background-image: url("https://assets.ubuntu.com/v1/12387180-navigation-menu-plain.svg");
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: 25px auto; }
+    @media only screen and (min-width: 620px) {
+      .banner .nav-toggle {
+        display: none; } }
+    .banner .nav-toggle .nav-toggle__link {
+      width: 48px;
+      height: 48px; }
+      .banner .nav-toggle .nav-toggle__link.open {
+        display: block; }
+      .banner .nav-toggle .nav-toggle__link.close {
+        display: none; }
+  @media only screen and (max-width: 620px) {
+    .banner #nav:hover ul {
+      display: block; }
+      .banner #nav:hover ul ul {
+        display: none; }
+    .banner #nav:hover .nav-toggle .nav-toggle__link.open {
+      display: none; }
+    .banner #nav:hover .nav-toggle .nav-toggle__link.close {
+      display: block; } }
+
+ol,
+ul {
+  margin-left: 20px;
+  margin-bottom: 20px; }
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+  margin-bottom: 0; }
+
+nav ul,
+nav ol {
+  list-style: none;
+  list-style-image: none; }
+
+li {
+  font-size: 1em;
+  line-height: 1.5;
+  margin: 0 0 .4em;
+  padding: 0; }
+
+.list-ticks li {
+  background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'><circle fill='%23c4c4c4' cx='7' cy='7' r='7'/><path fill='%23fff' d='M6.1 10.813L2.41 8.105l1.184-1.613L5.9 8.187l4.393-4.394 1.414 1.414z' /></svg>"); }
+
+.no-bullets {
+  list-style: none;
+  margin-left: 0; }
+
+.combined-list ul,
+.combined-list div {
+  margin-bottom: 0; }
+
+.combined-list .last-item {
+  border-bottom: 1px dotted #888;
+  padding-bottom: 10px; }
+
+.combined-list .last-col {
+  margin-bottom: 20px; }
+  .combined-list .last-col .last-item {
+    border-bottom: 0;
+    padding-bottom: 0; }
+
+@media only screen and (min-width: 768px) {
+  .combined-list ul,
+  .combined-list div {
+    margin-bottom: 20px; }
+  .combined-list .last-item {
+    border-bottom: 0;
+    padding-bottom: 0; } }
+
+.inline-list {
+  margin-left: 0; }
+  .inline-list li {
+    display: inline;
+    list-style: none;
+    margin-right: 20px; }
+  .inline-list .last-item {
+    margin-right: 0; }
+
+.list-step {
+  list-style: none;
+  margin-left: 60px; }
+
+@media only screen and (max-width: 1030px) {
+  .list-step__item:first-child {
+    margin-top: 10px; } }
+
+@media only screen and (min-width: 1030px) {
+  .list-step__title {
+    margin-bottom: 0; } }
+
+.list-step__bullet {
+  box-shadow: 0 1px 3px 1px rgba(51, 51, 51, 0.2);
+  background: #fff;
+  border-radius: 50%;
+  padding: .3em .68em;
+  display: inline-block;
+  color: #007aa6;
+  margin-right: .34375em;
+  margin-bottom: .625em;
+  margin-left: -60px; }
+  @media only screen and (max-width: 1030px) {
+    .list-step__bullet {
+      position: absolute;
+      top: -5px; } }
+
+@media only screen and (min-width: 768px) {
+  .grid-list {
+    display: flex;
+    flex-wrap: wrap; } }
+
+.grid-list__img {
+  display: block;
+  margin: auto;
+  max-width: 60px; }
+
+.grid-list p {
+  font-size: .875rem; }
+
+.grid-list__item {
+  border-bottom: 1px dotted #888;
+  margin-bottom: 30px;
+  display: flex; }
+  @media only screen and (max-width: 768px) {
+    .grid-list__item > [class*='-col']:first-child {
+      width: 25%;
+      padding-right: 1rem; }
+    .grid-list__item > [class*='-col']:last-child {
+      width: 75%; } }
+  .grid-list__item:last-child {
+    border-bottom: 0; }
+  @media only screen and (min-width: 768px) {
+    .grid-list__item {
+      display: flex;
+      flex-wrap: wrap;
+      border-right: 1px dotted #888;
+      margin: 0;
+      padding: 1.5em .75em 0; }
+      .grid-list__item.last-col {
+        border-right: 0; }
+      .grid-list__item.last-row {
+        border-bottom: 0; } }
+
+.row {
+  border-bottom: 1px dotted #888;
+  clear: both;
+  padding: 20px 10px 0;
+  position: relative; }
+  .row br {
+    display: none; }
+  .row.no-padding-bottom {
+    padding-bottom: 0; }
+  .row::after {
+    clear: both;
+    content: '.';
+    display: block;
+    height: 0;
+    visibility: hidden; }
+  .row--light {
+    background: #fff; }
+  .row--dark {
+    background: #333;
+    color: #fff; }
+  .row.row-grey, .row.row--grey {
+    background: #f7f7f7;
+    border: 0;
+    margin-top: -1px; }
+
+.no-border {
+  border: 0; }
+
+.row-hero {
+  margin-top: 20px;
+  padding-top: 0; }
+
+.strip {
+  width: 100%;
+  display: block; }
+
+.strip-inner-wrapper {
+  max-width: 1030px;
+  margin: auto; }
+
+@media only screen and (min-width: 768px) {
+  .row-hero {
+    margin-top: 40px; }
+  .row {
+    border-radius: 0;
+    margin: 0;
+    padding: 40px 20px 20px; }
+    .row-grey {
+      margin-top: -1px; } }
+
+@media only screen and (min-width: 769px) {
+  .row br {
+    display: block; } }
+
+@media only screen and (min-width: 1030px) {
+  .row br {
+    display: block; }
+  .row {
+    padding: 60px 20px 40px; }
+  .no-border {
+    border: 0; } }
+
+.header-search [type="search"],
+.header-search [type="text"],
+.search-form [type="search"],
+.search-form [type="text"] {
+  -webkit-appearance: none;
+  background-color: #dedede;
+  box-shadow: none;
+  color: #333;
+  display: block;
+  float: left;
+  font-size: 1em;
+  margin-bottom: 0;
+  padding: 12px 10px;
+  transition: all .5s ease-out;
+  width: 100%; }
+
+.header-search .svg-search-handle,
+.search-form .svg-search-handle {
+  fill: #333; }
+
+.header-search .svg-search-frame,
+.search-form .svg-search-frame {
+  stroke: #333; }
+
+.header-search placeholder,
+.search-form placeholder {
+  color: #333;
+  opacity: 1; }
+
+.header-search input:placeholder,
+.search-form input:placeholder {
+  color: #333;
+  opacity: 1; }
+
+.header-search ::placeholder,
+.search-form ::placeholder {
+  color: #333;
+  opacity: 1; }
+
+.header-search [type="search"]:focus,
+.search-form [type="search"]:focus {
+  background-color: lightgray;
+  border-color: #b3b3b3; }
+
+.header-search [type=submit],
+.search-form [type=submit] {
+  background: none;
+  display: block;
+  float: left;
+  line-height: 0;
+  margin-left: -40px;
+  overflow: visible;
+  padding: 3px 2px;
+  width: auto; }
+  .header-search [type=submit]:hover,
+  .search-form [type=submit]:hover {
+    background: none; }
+  .header-search [type=submit] img,
+  .search-form [type=submit] img {
+    height: 28px;
+    width: 28px;
+    margin-top: 2px; }
+
+.banner .search-toggle {
+  background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 90 90'><g color='%23333'><path fill='none' stroke-width='4' overflow='visible' enable-background='accumulate' d='M0 0h90v90H0z'/><path d='M69 36.5a33 33.5 0 1 1-66 0 33 33.5 0 1 1 66 0z' transform='matrix(.636 0 0 .627 16.114 16.12)' fill='none' stroke='%23333' stroke-width='9.5' overflow='visible' enable-background='accumulate'/><path d='M55.77 52.92L52.94 55.75l14 14 2.83-2.83-14-14z' font-size='xx-small' fill='%23333' stroke-width='6' overflow='visible' enable-background='accumulate' font-family='Sans' class='s0'/><path d='M60.97 57.03c-1.55-3.04 1.02-3.63 2.46-0.58 1.44-0.21 3.21 4.29l9.19 9.2c2.68 2.85 3.26 2.46 5.64 2.38-2.38 2.77-2.79-0.08-5.65l-9.19-9.2c-0.73-0.75-1.78-1.19-2.83-1.19z' font-size='xx-small' fill='%23333' stroke-width='11.8' overflow='visible' enable-background='accumulate' font-family='Sans' class='s0'/></g></svg>");
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  display: block;
+  height: 48px;
+  outline: none;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  text-indent: -999em;
+  top: 0;
+  width: 24px; }
+  .banner .search-toggle .search-toggle__link {
+    width: 48px;
+    height: 48px; }
+    .banner .search-toggle .search-toggle__link.open {
+      display: block; }
+    .banner .search-toggle .search-toggle__link.close {
+      display: none; }
+
+#site-search:hover form {
+  display: block; }
+
+#site-search:hover .search-toggle .search-toggle__link.open {
+  display: none; }
+
+#site-search:hover .search-toggle .search-toggle__link.close {
+  display: block; }
+
+.header-search,
+.search-form {
+  background: #f7f7f7;
+  border: 0;
+  display: none;
+  float: left;
+  position: relative;
+  margin: 0;
+  width: 100%;
+  z-index: 3; }
+
+.search-form.active,
+.header-search.active,
+.header-search.open {
+  display: block; }
+
+.search-form div,
+.header-search div {
+  box-shadow: inset 0 -4px 4px -4px rgba(0, 0, 0, 0.3), inset 0 5px 5px -5px rgba(0, 0, 0, 0.3);
+  background: white;
+  margin: 10px;
+  position: relative;
+  z-index: 1; }
+
+.search-form form [type="search"],
+.header-search form [type="search"] {
+  background: #fff;
+  border: 0;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3) inset, 0 -1px 3px rgba(0, 0, 0, 0.2) inset, 0 2px 0 rgba(255, 255, 255, 0.4);
+  color: #333;
+  display: block;
+  float: left;
+  font-size: 1em;
+  height: auto;
+  margin: 0;
+  padding: 8px 10px;
+  width: 100%; }
+
+.yes-js .header-inner .search-form,
+.yes-js .header-inner .header-search {
+  display: none; }
+  .yes-js .header-inner .search-form form,
+  .yes-js .header-inner .header-search form {
+    margin-left: 0;
+    margin-right: 0;
+    overflow: hidden;
+    padding: 10px;
+    position: relative;
+    top: 0;
+    width: 100%;
+    z-index: 999; }
+
+@media only screen and (max-width: 620px) {
+  .banner .search-toggle {
+    right: 0; }
+  .no-svg .search-toggle,
+  .opera-mini .search-toggle {
+    background-image: url("https://assets.ubuntu.com/v1/75d8151d-search-white.png"); } }
+
+@media only screen and (min-width: 620px) {
+  .banner .search-toggle {
+    display: none; } }
+
+@media only screen and (min-width: 620px) {
+  .search-form,
+  .header-search {
+    background: none;
+    border-right: 0 none;
+    float: right;
+    margin-bottom: 0;
+    max-width: 220px;
+    overflow: hidden;
+    padding: 7px 0 5px 14px; }
+    .search-form form [type="text"],
+    .search-form form [type="search"],
+    .header-search form [type="text"],
+    .header-search form [type="search"] {
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4) inset;
+      box-sizing: content-box;
+      background-color: #dedede;
+      border: 0 solid #d8d8d8;
+      border-width: 0 0 1px;
+      color: #333;
+      font-size: .813em;
+      height: 24px;
+      margin-bottom: 0;
+      padding: .5em 2.5em .5em .5em;
+      transition: all .5s ease 0s;
+      width: 86px; }
+      .search-form form [type="text"]:focus,
+      .search-form form [type="search"]:focus,
+      .header-search form [type="text"]:focus,
+      .header-search form [type="search"]:focus {
+        background-color: lightgray;
+        border-color: #c4c4c4; }
+    .search-form .svg-search-handle,
+    .header-search .svg-search-handle {
+      fill: #333; }
+    .search-form .svg-search-frame,
+    .header-search .svg-search-frame {
+      stroke: #333; }
+    .search-form placeholder,
+    .header-search placeholder {
+      color: #333; }
+    .search-form input:placeholder,
+    .header-search input:placeholder {
+      color: #333; }
+    .search-form ::placeholder,
+    .header-search ::placeholder {
+      color: #333; } }
+
+@media only screen and (min-width: 620px) {
+  .header-search .svg-search-handle,
+  .search-form .svg-search-handle {
+    fill: #333; }
+  .header-search .svg-search-frame,
+  .search-form .svg-search-frame {
+    stroke: #333; }
+  .header-search placeholder,
+  .search-form placeholder {
+    color: #333; }
+  .header-search input:placeholder,
+  .search-form input:placeholder {
+    color: #333; }
+  .header-search ::placeholder,
+  .search-form ::placeholder {
+    color: #333; } }
+
+@media only screen and (max-width: 620px) {
+  .banner .nav-primary .header-search {
+    position: relative;
+    top: 0;
+    width: 100%; }
+    .banner .nav-primary .header-search [type="search"] {
+      background-color: #ebebeb;
+      color: #333; }
+    .banner .nav-primary .header-search [type="submit"] {
+      background-color: transparent;
+      height: 38px;
+      margin-top: 0;
+      width: 32px; }
+      .banner .nav-primary .header-search [type="submit"] img,
+      .banner .nav-primary .header-search [type="submit"] svg {
+        max-width: none; }
+    .banner .nav-primary .header-search.open {
+      display: block; }
+  .banner .search-toggle {
+    background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 90 90'><g color='%23333'><path fill='none' stroke-width='4' overflow='visible' enable-background='accumulate' d='M0 0h90v90H0z'/><path d='M69 36.5a33 33.5 0 1 1-66 0 33 33.5 0 1 1 66 0z' transform='matrix(.636 0 0 .627 16.114 16.12)' fill='none' stroke='%23333' stroke-width='9.5' overflow='visible' enable-background='accumulate'/><path d='M55.77 52.92L52.94 55.75l14 14 2.83-2.83-14-14z' font-size='xx-small' fill='%23333' stroke-width='6' overflow='visible' enable-background='accumulate' font-family='Sans' class='s0'/><path d='M60.97 57.03c-1.55-3.04 1.02-3.63 2.46-0.58 1.44-0.21 3.21 4.29l9.19 9.2c2.68 2.85 3.26 2.46 5.64 2.38-2.38 2.77-2.79-0.08-5.65l-9.19-9.2c-0.73-0.75-1.78-1.19-2.83-1.19z' font-size='xx-small' fill='%23333' stroke-width='11.8' overflow='visible' enable-background='accumulate' font-family='Sans' class='s0'/></g></svg>");
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: 25px auto;
+    cursor: pointer;
+    display: block;
+    height: 48px;
+    position: absolute;
+    right: 0;
+    text-indent: -99999px;
+    width: 48px; }
+  .no-svg .banner .search-toggle,
+  .opera-mini .banner .search-toggle {
+    background-image: url("https://assets.ubuntu.com/v1/2196e362-search-white.svg"); }
+  .opera-mini x:-o-prefocus,
+  .opera-mini .banner .search-toggle {
+    background-size: 25px auto; } }
+
+@media only screen and (min-width: 620px) {
+  .search-form,
+  .header-search {
+    display: block; }
+    .search-form .svg-search-handle,
+    .header-search .svg-search-handle {
+      fill: #333; }
+    .search-form .svg-search-frame,
+    .header-search .svg-search-frame {
+      stroke: #333; }
+    .search-form form [type="text"]:focus,
+    .header-search form [type="text"]:focus {
+      width: 160px; }
+    .search-form [type="search"],
+    .search-form [type="text"],
+    .header-search [type="search"],
+    .header-search [type="text"] {
+      padding: 8px 10px; } }
+
+@media only screen and (max-width: 1030px) {
+  .search-form,
+  .header-search {
+    margin-right: 10px; } }
+
+@media only screen and (max-width: 620px) {
+  .banner .search-toggle {
+    right: 48px; } }
+
+.ubuntu-search .nav-secondary,
+.search-results .nav-secondary,
+.search-no-results .nav-secondary {
+  display: none; }
+
+.ubuntu-search section > h1,
+.ubuntu-search section article h1,
+.search-results section > h1,
+.search-results section article h1,
+.search-no-results section > h1,
+.search-no-results section article h1 {
+  padding-bottom: 10px;
+  font-size: 1.438em;
+  margin-bottom: 0; }
+
+.ubuntu-search section > h1,
+.search-results section > h1,
+.search-no-results section > h1 {
+  border-bottom: 1px dotted #cdcdcd; }
+
+.ubuntu-search .main-search,
+.search-results .main-search,
+.search-no-results .main-search {
+  background-color: transparent;
+  margin: 0 0 20px;
+  padding: 20px 0; }
+  .ubuntu-search .main-search [type="search"],
+  .search-results .main-search [type="search"],
+  .search-no-results .main-search [type="search"] {
+    border: 1px solid #888;
+    float: left;
+    font-size: 2em;
+    padding: .2em 65px .2em .2em;
+    width: 100%; }
+  .ubuntu-search .main-search [type=submit],
+  .search-results .main-search [type=submit],
+  .search-no-results .main-search [type=submit] {
+    width: 32px;
+    height: 38px;
+    background-repeat: no-repeat;
+    background-position: center 8px;
+    background-color: transparent;
+    background-size: 28px 28px;
+    display: block;
+    float: left;
+    line-height: 0;
+    margin-left: -53px;
+    margin-top: -4px;
+    overflow: visible;
+    padding: 4px; }
+    .ubuntu-search .main-search [type=submit] img,
+    .search-results .main-search [type=submit] img,
+    .search-no-results .main-search [type=submit] img {
+      height: 45px;
+      width: 45px; }
+  .ubuntu-search .main-search [type=submit]:hover,
+  .search-results .main-search [type=submit]:hover,
+  .search-no-results .main-search [type=submit]:hover {
+    background: none; }
+
+.ubuntu-search .search-result h1 .title-main,
+.search-results .search-result h1 .title-main,
+.search-no-results .search-result h1 .title-main {
+  margin-right: 20px; }
+
+.ubuntu-search .search-result h1 .result-url,
+.search-results .search-result h1 .result-url,
+.search-no-results .search-result h1 .result-url {
+  color: #888;
+  display: block;
+  overflow: hidden;
+  padding-bottom: 2px;
+  text-overflow: ellipsis;
+  vertical-align: bottom; }
+  .ubuntu-search .search-result h1 .result-url a,
+  .search-results .search-result h1 .result-url a,
+  .search-no-results .search-result h1 .result-url a {
+    color: #888; }
+
+.ubuntu-search .search-result p,
+.search-results .search-result p,
+.search-no-results .search-result p {
+  margin-bottom: 0; }
+
+.ubuntu-search .num-results,
+.search-results .num-results,
+.search-no-results .num-results {
+  display: inline-block;
+  margin-left: 20px; }
+
+.ubuntu-search .bottom-results-total,
+.search-results .bottom-results-total,
+.search-no-results .bottom-results-total {
+  margin: 0;
+  overflow: visible;
+  padding-top: 20px;
+  text-align: center;
+  width: 100%; }
+
+.ubuntu-search .bottom-nav,
+.search-results .bottom-nav,
+.search-no-results .bottom-nav {
+  margin-top: -26px;
+  overflow: hidden; }
+  .ubuntu-search .bottom-nav ul,
+  .search-results .bottom-nav ul,
+  .search-no-results .bottom-nav ul {
+    margin-bottom: 0;
+    margin-left: 0;
+    overflow: hidden;
+    padding: 0; }
+  .ubuntu-search .bottom-nav li,
+  .search-results .bottom-nav li,
+  .search-no-results .bottom-nav li {
+    float: left;
+    margin-left: 15px; }
+  .ubuntu-search .bottom-nav li:first-child,
+  .search-results .bottom-nav li:first-child,
+  .search-no-results .bottom-nav li:first-child {
+    margin-left: 0; }
+
+.ubuntu-search .nav-back,
+.search-results .nav-back,
+.search-no-results .nav-back {
+  float: left; }
+  .ubuntu-search .nav-back li:before,
+  .search-results .nav-back li:before,
+  .search-no-results .nav-back li:before {
+    color: #f7f7f7;
+    content: '\2039';
+    /* left chevron &lsaquo; */
+    margin-right: 5px; }
+  .ubuntu-search .nav-back .item-extreme:before,
+  .search-results .nav-back .item-extreme:before,
+  .search-no-results .nav-back .item-extreme:before {
+    content: '\2039\2039';
+    /* double left chevron &lsaquo; */ }
+
+.ubuntu-search .nav-forward,
+.search-results .nav-forward,
+.search-no-results .nav-forward {
+  float: right; }
+  .ubuntu-search .nav-forward li:after,
+  .search-results .nav-forward li:after,
+  .search-no-results .nav-forward li:after {
+    color: #f7f7f7;
+    content: '\203A';
+    /* right chevron&nbsp;&rsaquo; */
+    margin-left: 5px; }
+  .ubuntu-search .nav-forward .item-extreme:after,
+  .search-results .nav-forward .item-extreme:after,
+  .search-no-results .nav-forward .item-extreme:after {
+    content: '\203A\203A';
+    /* double right chevron&nbsp;&rsaquo; */ }
+
+.ubuntu-search .error-notification,
+.search-results .error-notification,
+.search-no-results .error-notification {
+  background-color: #fff;
+  color: #333;
+  display: block;
+  margin-top: 20px;
+  padding: 20px;
+  width: 100%; }
+
+.ubuntu-search .result-line,
+.search-results .result-line,
+.search-no-results .result-line {
+  color: #888; }
+
+.ubuntu-search .results-top,
+.search-results .results-top,
+.search-no-results .results-top {
+  border-bottom: 1px dotted #cdcdcd;
+  padding-bottom: .5em; }
+
+.ubuntu-search .search-container,
+.search-results .search-container,
+.search-no-results .search-container {
+  padding-bottom: 0; }
+
+@media only screen and (min-width: 620px) {
+  .ubuntu-search .main-search [type=submit] {
+    margin-left: -60px;
+    margin-top: 0; } }
+
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: normal;
+  font-weight: 300;
+  src: url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-l-webfont.woff2") format("woff2"), url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-l-webfont.woff") format("woff"); }
+
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: normal;
+  font-weight: 400;
+  src: url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-r-webfont.woff2") format("woff2"), url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-r-webfont.woff") format("woff"); }
+
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: normal;
+  font-weight: 700;
+  src: url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-b-webfont.woff2") format("woff2"), url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-b-webfont.woff") format("woff"); }
+
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: italic;
+  font-weight: 300;
+  src: url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-li-webfont.woff2") format("woff2"), url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-li-webfont.woff") format("woff"); }
+
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: italic;
+  font-weight: 400;
+  src: url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-ri-webfont.woff2") format("woff2"), url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-ri-webfont.woff") format("woff"); }
+
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: italic;
+  font-weight: 700;
+  src: url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-bi-webfont.woff2") format("woff2"), url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntu-bi-webfont.woff") format("woff"); }
+
+@font-face {
+  font-family: 'Ubuntu Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntumono-r-webfont.woff2") format("woff2"), url("https://assets.ubuntu.com/sites/ubuntu/latest/u/fonts/ubuntumono-r-webfont.woff") format("woff"); }
+
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
+
+body {
+  color: #333;
+  font-family: Ubuntu, Arial, 'libra sans', sans-serif;
+  font-size: 16px;
+  font-weight: 300; }
+
+a:focus {
+  outline: thin dotted; }
+
+a:hover,
+a:active {
+  outline: 0; }
+
+a {
+  color: #007aa6;
+  text-decoration: none; }
+
+a:hover,
+a:active,
+a:focus {
+  text-decoration: underline; }
+
+strong {
+  font-weight: 400; }
+
+.caps-centered,
+.muted-heading {
+  font-size: .875em;
+  margin-bottom: 20px;
+  text-align: center;
+  text-transform: uppercase; }
+
+small,
+.smaller {
+  font-size: 13px; }
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline; }
+
+sup {
+  vertical-align: text-top; }
+
+sub {
+  vertical-align: text-bottom; }
+
+p + h2,
+ul + h2,
+ol + h2,
+pre + h2 {
+  margin-top: 0.5625em; }
+
+header nav a:link {
+  font-weight: normal; }
+
+p + h3,
+ul + h3,
+ol + h3,
+pre + h3 {
+  margin-top: .783em; }
+
+p + h4,
+ul + h4,
+ol + h4,
+pre + h4 {
+  margin-top: 1.21875; }
+
+ol + h2,
+p + h2,
+pre + h2,
+ul + h2 {
+  margin-top: .563em; }
+
+ol + h3,
+p + h3,
+pre + h3,
+ul + h3 {
+  margin-top: .783em; }
+
+ol + h4,
+p + h4,
+pre + h4,
+ul + h4 {
+  margin-top: 1.219em; }
+
+.intro {
+  font-size: 1em;
+  line-height: 1.4; }
+
+.row div p:last-child,
+.row ul p:last-child {
+  margin-bottom: 0; }
+
+.four-col p:last-child {
+  margin-bottom: 0; }
+
+.note {
+  color: #888;
+  font-size: .813em; }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: Ubuntu, Arial, 'libra sans', sans-serif;
+  font-weight: 300;
+  line-height: 1.3; }
+
+h1,
+.heading-1 {
+  font-size: 2.8125em;
+  margin-bottom: .5em; }
+
+h2,
+.heading-2 {
+  font-size: 2em;
+  margin-bottom: .5em; }
+
+h3,
+.heading-3 {
+  font-size: 1.4375em;
+  margin-bottom: .522em; }
+
+h4,
+.heading-4 {
+  font-size: 1.25em;
+  font-weight: 400;
+  margin-bottom: .615em; }
+
+h5,
+.heading-5 {
+  font-size: 1em;
+  font-weight: 700;
+  margin-bottom: 1em; }
+
+h6,
+.heading-6 {
+  font-size: .8125em;
+  font-weight: 400;
+  margin-bottom: 1em;
+  letter-spacing: .1em;
+  text-transform: uppercase; }
+
+p,
+li {
+  font-size: 1em;
+  line-height: 1.5;
+  margin: 0;
+  margin-bottom: .75em;
+  padding: 0; }
+
+button,
+input,
+select,
+textarea {
+  font-family: Ubuntu,Arial,'libra sans',sans-serif; }
+
+@media only screen and (min-width: 768px) and (max-width: 1030px) {
+  h1 {
+    font-size: 1.5234375em;
+    margin-bottom: .5em; }
+  h2 {
+    font-size: 1.348125em;
+    margin-bottom: .5em; }
+  h3 {
+    font-size: 1.1428125em;
+    margin-bottom: .522em; }
+  h4 {
+    font-size: 1.171875em;
+    font-weight: 400;
+    margin-bottom: .615em; }
+  h5 {
+    font-size: .9375em;
+    font-weight: 700;
+    margin-bottom: 1em; }
+  h6 {
+    font-size: .6778125em;
+    font-weight: 400;
+    margin-bottom: 1em;
+    letter-spacing: .1em;
+    text-transform: uppercase; }
+  .intro {
+    font-size: 1.13333em; } }
+
+@media only screen and (max-width: 768px) {
+  h1 {
+    font-size: 1.421875em;
+    margin-bottom: .4375em; }
+  h2 {
+    font-size: 1.25825em;
+    margin-bottom: .4375em; }
+  h3 {
+    font-size: 1.066625em;
+    margin-bottom: .45675em; }
+  h4 {
+    font-size: 1.09375em;
+    font-weight: 400;
+    margin-bottom: .538125em; }
+  h5 {
+    font-size: .875em;
+    font-weight: 700;
+    margin-bottom: .875em; }
+  h6 {
+    font-size: .632625em;
+    font-weight: 400;
+    margin-bottom: .875em;
+    letter-spacing: .1em;
+    text-transform: uppercase; }
+  p,
+  li {
+    font-size: .875rem; } }
+
+@media only screen and (min-width: 1030px) {
+  p,
+  li,
+  code,
+  pre {
+    font-size: 16px;
+    line-height: 1.5;
+    margin-bottom: .75em; }
+  .intro {
+    font-size: 1.25em; } }
+
+dfn {
+  font-style: italic; }
+
+code,
+pre {
+  font-family: 'Ubuntu Mono', 'Consolas', 'Monaco', 'Lucida Console', 'Courier New', Courier, monospace; }
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  overflow-x: scroll;
+  margin-bottom: 20px;
+  margin: 0 0 2.5em;
+  width: 100%; }
+  table th,
+  table td {
+    background: #f7f7f7;
+    border: 1px dotted #888;
+    padding: 15px 10px; }
+  table td {
+    text-align: center;
+    vertical-align: middle; }
+  table thead th {
+    border-collapse: separate;
+    border-spacing: 0 10px;
+    background: #fee3d2;
+    color: #333;
+    font-weight: normal; }
+  table tbody th {
+    font-weight: 300;
+    text-align: left; }
+  table th[scope='col'] {
+    text-align: center; }
+  table thead th:first-of-type {
+    text-align: left; }
+
+@media only screen and (max-width: 768px) {
+  table {
+    display: block; } }
+
+body footer.global #nav-global li:first-of-type a {
+  margin-left: 0; }
+
+footer.global {
+  background: none;
+  border-top: 0;
+  box-shadow: inset 0 2px 2px -1px #cdcdcd;
+  clear: both;
+  display: block;
+  padding: 30px 10px 20px;
+  position: relative;
+  width: 100%; }
+  footer.global .legal {
+    background-image: none;
+    clear: both;
+    margin: 0 auto;
+    min-height: 40px;
+    position: relative;
+    width: 100%; }
+    footer.global .legal p,
+    footer.global .legal ul {
+      padding-left: 0; }
+  footer.global h2 {
+    font-size: .75em;
+    line-height: 1.4;
+    margin-bottom: 0;
+    padding-bottom: .5em; }
+  footer.global h2,
+  footer.global h2 a:link,
+  footer.global h2 a:visited {
+    color: #333;
+    font-weight: normal; }
+  footer.global ul {
+    margin: 0; }
+  footer.global li a:hover {
+    color: #007aa6; }
+  footer.global li ul li a:link,
+  footer.global li ul li a:visited {
+    color: #333;
+    font-size: .75em; }
+  footer.global h2 a:hover,
+  footer.global h2 a:active {
+    color: #007aa6; }
+  footer.global p {
+    color: #333;
+    font-size: 12px;
+    margin-bottom: 0; }
+
+@media only screen and (max-width: 768px) {
+  footer.no-global .legal {
+    box-shadow: 0 2px 2px -1px #cdcdcd inset;
+    box-sizing: content-box;
+    margin-left: -10px;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 10px; } }
+
+@media only screen and (min-width: 1030px) {
+  footer.global .legal {
+    width: 1030px; }
+  footer.global {
+    padding: 30px 0 20px; } }
+
+svg:not(:root) {
+  overflow: hidden; }
+
+figure {
+  width: 100%; }
+  figure caption {
+    display: block;
+    width: 100%;
+    text-align: center; }
+
+object,
+iframe,
+embed,
+canvas,
+video,
+audio {
+  display: block;
+  max-width: 100%;
+  margin: 0 auto 20px; }
+
+audio:not([controls]) {
+  display: none;
+  height: 0; }
+
+[hidden] {
+  display: none; }
+
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden; }
+  .video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%; }
+  .video-container h3,
+  .video-container .video-title {
+    margin-top: 20px; }
+
+.inline-logos {
+  float: left;
+  margin-left: 0;
+  padding: 0;
+  text-align: center;
+  width: 100%; }
+  .inline-logos .inline-logos__item {
+    display: inline-block;
+    margin-right: 20px;
+    padding: 0 0 20px;
+    width: 36%; }
+    @media only screen and (max-width: 300px) {
+      .inline-logos .inline-logos__item {
+        margin: 0 0 20px;
+        width: 100%; } }
+    .inline-logos .inline-logos__item.clear-row {
+      clear: left; }
+    .inline-logos .inline-logos__item.last-item {
+      border: 0; }
+  .inline-logos .inline-logos__image {
+    max-height: 32px;
+    max-width: 115px;
+    transition: all .3s ease-out;
+    vertical-align: middle; }
+
+@media only screen and (min-width: 768px) {
+  .inline-logos {
+    padding-top: 20px; }
+    .inline-logos .inline-logos__item {
+      display: inline-block;
+      height: 56px;
+      line-height: 60px;
+      margin: 0 30px 30px;
+      width: 150px; }
+    .inline-logos .inline-logos__image {
+      float: none;
+      height: auto;
+      max-height: 56px;
+      max-width: 150px;
+      vertical-align: middle; } }
+
+@media only screen and (min-width: 1030px) {
+  .inline-logos__item {
+    margin-bottom: 40px; } }
+
+@media only screen and (min-width: 768px) {
+  .equal-height__align-vertically {
+    align-items: center;
+    justify-content: center; } }
+
+@media only screen and (min-width: 768px) {
+  .equal-height--vertical-divider {
+    position: relative; }
+    .equal-height--vertical-divider__item {
+      padding-left: 10px;
+      padding-right: 10px; }
+      .equal-height--vertical-divider__item:before {
+        content: '';
+        position: absolute;
+        right: -10px;
+        top: 0;
+        height: 100%;
+        width: 1px;
+        border-right: 1px dotted #888; }
+    .equal-height--vertical-divider .last-col, .equal-height--vertical-divider__item:last-of-type {
+      padding-right: 0; }
+      .equal-height--vertical-divider .last-col:before, .equal-height--vertical-divider__item:last-of-type:before {
+        border-right: 0; }
+    .equal-height--vertical-divider__item:first-of-type {
+      padding-left: 0; } }
+
+@media only screen and (max-width: 768px) {
+  .equal-height--vertical-divider .equal-height--vertical-divider__item {
+    border-bottom: 1px dotted #888;
+    padding-bottom: 20px; }
+  .equal-height--vertical-divider .equal-height--vertical-divider__item:last-of-type {
+    border-bottom: 0;
+    padding-bottom: inherit; } }
+
+.wrapper {
+  max-width: 1030px;
+  margin: auto;
+  padding: 1rem; }
+  .docs .wrapper {
+    padding: 0; }
+  @media only screen and (min-width: 768px) {
+    .wrapper {
+      padding: 0; } }
+
+.row {
+  padding-top: 40px;
+  padding-bottom: 20px; }
+  @media only screen and (min-width: 768px) {
+    .row {
+      padding-top: 80px;
+      padding-bottom: 60px; } }
+
+.strip-dark {
+  background: #333;
+  color: #fff; }
+  .strip-dark a {
+    color: #fff; }
+
+.row-grey {
+  border: 0;
+  margin-top: -1px; }
+
+.grid-list__item img {
+  width: 60px; }
+
+.grid-list__item h3 {
+  font-size: 1.25rem; }
+
+.diagram {
+  padding: 0 1.5rem; }
+  .diagram img {
+    width: 100%; }
+  .diagram--wide {
+    width: 100%; }
+
+.command-inline {
+  position: relative;
+  display: inline;
+  border-radius: 4px;
+  background-color: none;
+  overflow: hidden;
+  font-size: 1em;
+  font-family: Ubuntu Mono;
+  font-weight: 300;
+  padding: 0;
+  width: 100%; }
+
+.complementing-note {
+  margin: 1rem auto 1rem;
+  text-align: center;
+  font-style: italic;
+  width: 100%; }
+  @media only screen and (min-width: 768px) {
+    .complementing-note {
+      max-width: 60%; } }
+
+.box {
+  border: 1px solid #d2d2d2;
+  border-radius: 3px;
+  position: relative;
+  background: #fff;
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap; }
+  .box a {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap; }
+    .box a img {
+      justify-content: center; }
+  .box p a {
+    display: inline-block; }
+  .box__txt {
+    align-self: flex-end;
+    display: block;
+    margin: 1rem 0 0;
+    text-align: center;
+    width: 100%; }
+  .box__img {
+    width: 100%;
+    max-width: 118px;
+    max-height: 118px;
+    display: block;
+    margin: auto;
+    padding: 0 1rem; }
+  .box__link {
+    display: inline-block; }
+  .box__img-wrap {
+    min-height: 100px;
+    width: 100%;
+    display: flex; }
+  .box .external {
+    display: inline-block; }
+  @media only screen and (min-width: 1030px) {
+    .box {
+      padding: 1rem; }
+      .partner-list .box {
+        display: flex;
+        align-items: center;
+        justify-content: center; }
+      .support .box {
+        padding: 2rem; } }
+
+.command-line {
+  position: relative;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  overflow: hidden;
+  font-size: 1em;
+  font-family: Ubuntu Mono;
+  font-weight: 300;
+  padding: .7em 1em;
+  color: #333;
+  width: 100%; }
+  .command-line code {
+    white-space: pre-wrap; }
+  .command-line b,
+  .command-line strong {
+    font-weight: bold; }
+
+.footer {
+  padding: 2rem 1rem 1rem;
+  font-size: .75rem; }
+  .footer__text {
+    font-size: .75rem; }
+  .footer__links {
+    list-style: none;
+    padding: 0;
+    margin: 0; }
+  .footer__list-item {
+    display: inline-block;
+    font-size: .75rem; }
+  .footer__dot {
+    display: inline-block;
+    font-size: 1rem;
+    padding: 0 .25rem; }
+  .footer__heading {
+    color: #888;
+    font-size: 1em;
+    letter-spacing: .05em;
+    margin-bottom: 0;
+    padding-bottom: .75em;
+    text-transform: uppercase; }
+  @media only screen and (max-width: 600px) {
+    .footer__social, .footer__text {
+      width: 100%; } }
+  @media only screen and (min-width: 1030px) {
+    .footer {
+      padding: 2rem 0 1rem; } }
+
+.footer-wrapper {
+  -webkit-box-shadow: inset 0 2px 2px -1px #cdcdcd;
+  box-shadow: inset 0 2px 2px -1px #cdcdcd;
+  padding-top: 30px;
+  padding-bottom: 20px;
+  padding-left: 1rem;
+  padding-right: 1rem; }
+
+.banner {
+  background: #fff;
+  max-width: 1030px; }
+  .banner .nav-toggle {
+    background-image: url("https://assets.ubuntu.com/v1/1fd83579-navigation-menu-black.svg"); }
+  .banner .logo {
+    height: 48px;
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: 20px;
+    margin-right: 20px; }
+    .docs .banner .logo {
+      margin-left: 20px; }
+    @media only screen and (min-width: 1060px) {
+      .banner .logo {
+        margin-left: 0; } }
+    @media only screen and (min-width: 768px) {
+      .banner .logo {
+        height: 51px; } }
+    .banner .logo img {
+      height: 28px;
+      display: block; }
+  .banner .nav-primary ul {
+    float: right; }
+    @media only screen and (min-width: 620px) {
+      .banner .nav-primary ul li {
+        border-bottom: 3px solid transparent; }
+        .banner .nav-primary ul li.active {
+          border-bottom: 3px solid #e95420; }
+        .banner .nav-primary ul li:hover {
+          background-color: #e3e3e3 !important; } }
+    .banner .nav-primary ul li:last-child {
+      border-right: 1px solid #e3e3e3;
+      border-left: 1px solid #e3e3e3; }
+      .docs .banner .nav-primary ul li:last-child {
+        border-right: 0;
+        padding-right: 0; }
+    .banner .nav-primary ul li a {
+      border: 0; }
+      .banner .nav-primary ul li a:link, .banner .nav-primary ul li a:visited {
+        background-color: transparent;
+        border: 0; }
+        .banner .nav-primary ul li a:link:hover, .banner .nav-primary ul li a:visited:hover {
+          background-color: transparent; }
+      .banner .nav-primary ul li a.external, .banner .nav-primary ul li a.external:link, .banner .nav-primary ul li a.external:link:hover {
+        color: #333;
+        background-image: url("https://assets.ubuntu.com/v1/7d47725b-external-link.svg");
+        background-position: right 1rem top 1rem;
+        background-size: 7px 7px;
+        background-repeat: no-repeat;
+        background-color: transparent;
+        padding-right: 2rem; }
+  @media only screen and (min-width: calc($site-max-width + 2rem)) {
+    .banner .nav-primary {
+      padding: 0; } }
+  .docs .banner .nav-primary {
+    max-width: 100%;
+    padding: 0; }
+
+.directory-highlight {
+  color: #19b6ee; }
+
+.bin-highlight {
+  color: #38b44a; }
+
+.image-highlight {
+  color: #77216f; }
+
+.key-highlight {
+  color: #19b6ee; }
+
+.key-l2-highlight {
+  color: #df382c; }
+
+.key-l3-highlight {
+  color: #888; }
+
+.string-highlight {
+  color: #38b44a; }
+
+.inline-logos {
+  padding-top: 20px; }
+  .inline-logos .inline-logos__item {
+    margin: 0;
+    height: auto; }
+    @media only screen and (min-width: 768px) {
+      .inline-logos .inline-logos__item {
+        margin-right: 20px;
+        margin-bottom: 20px;
+        width: 180px;
+        padding: 20px; } }
+    @media only screen and (max-width: 768px) {
+      .inline-logos .inline-logos__item {
+        margin-right: 20px;
+        margin-bottom: 20px;
+        width: 140px;
+        padding: 10px; } }
+
+@media only screen and (min-width: 768px) {
+  .inline-logos .inline-logos__image {
+    max-height: 90px;
+    max-width: 130px;
+    margin: auto; } }
+
+@media only screen and (max-width: 768px) {
+  .inline-logos .inline-logos__image {
+    max-width: 110px;
+    margin: auto; } }
+
+.grid-list h3 {
+  margin-top: .2em; }
+
+.equal-height__align-vertically {
+  align-items: flex-start; }
+
+.hero-row {
+  background-color: #f7f7f7;
+  background-image: url("https://assets.ubuntu.com/v1/0a11c33e-meizu-pro5-background.png");
+  background-position: center right;
+  background-size: cover;
+  border-bottom: 0;
+  padding-top: 20px;
+  padding-bottom: 0; }
+  .hero-row .intro {
+    font-size: .875rem; }
+  @media only screen and (min-width: 768px) {
+    .hero-row {
+      padding-top: 60px;
+      padding-bottom: 20px; }
+      .hero-row .intro {
+        font-size: 23px;
+        line-height: 1.5; } }
+  @media only screen and (min-width: 984px) {
+    .hero-row__heading {
+      margin-top: 2rem; } }
+
+.social-list {
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0; }
+  .social-list__item--twitter, .social-list__item--google-plus, .social-list__item--facebook, .social-list__item--youtube {
+    margin-right: 20px;
+    float: left;
+    text-indent: -99999px;
+    background-image: url("https://assets.ubuntu.com/v1/ea75daef-build.snapcraft.social.svg");
+    background-repeat: no-repeat;
+    height: 45px;
+    width: 45px;
+    overflow: hidden;
+    display: inline-block; }
+    .social-list__item--twitter:hover, .social-list__item--google-plus:hover, .social-list__item--facebook:hover, .social-list__item--youtube:hover {
+      background-position-y: -45px; }
+  .social-list__item--twitter {
+    background-position: 0 0; }
+  .social-list__item--google-plus {
+    background-position: -45px 0; }
+  .social-list__item--facebook {
+    background-position: -90px 0; }
+  .social-list__item--youtube {
+    background-position: -135px 0; }
+
+.responsive-tabs .command-line {
+  padding: 0; }
+
+.responsive-tabs__nav,
+.r-tabs .r-tabs-nav {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  width: 100%;
+  justify-content: center;
+  list-style-type: none;
+  margin: 0;
+  margin-left: -20px;
+  padding: 0; }
+  .responsive-tabs__nav a,
+  .r-tabs .r-tabs-nav a {
+    outline: none; }
+
+.responsive-tabs__nav-item {
+  text-align: center;
+  align-self: flex-end;
+  margin-left: 20px;
+  margin-bottom: 0;
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-bottom: 10px;
+  float: left; }
+
+.responsive-tabs__image {
+  max-width: 127px; }
+
+.responsive-tabs__link,
+.responsive-tabs__link:active {
+  height: 100%;
+  display: block;
+  outline: none; }
+
+.r-tabs .r-tabs-panel {
+  background: #f7f7f7;
+  border: 1px solid #e1e1e1;
+  display: none;
+  padding: 20px;
+  padding-bottom: 10px; }
+
+.r-tabs .r-tabs-accordion-title {
+  display: none; }
+
+.r-tabs .r-tabs-panel.r-tabs-state-active {
+  display: block; }
+
+.responsive-tabs__nav-item.r-tabs-state-active {
+  position: relative;
+  background: #fff;
+  z-index: 1; }
+  .responsive-tabs__nav-item.r-tabs-state-active::before, .responsive-tabs__nav-item.r-tabs-state-active::after {
+    top: 100%;
+    left: 50%;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none; }
+  .responsive-tabs__nav-item.r-tabs-state-active::after {
+    border-color: rgba(255, 255, 255, 0);
+    border-top-color: #fff;
+    border-width: 10px;
+    margin-left: -10px; }
+  .responsive-tabs__nav-item.r-tabs-state-active::before {
+    border-color: rgba(225, 225, 225, 0);
+    border-top-color: #d5d5d5;
+    border-width: 11px;
+    margin-left: -11px; }
+
+@media only screen and (max-width: 767px) {
+  .r-tabs .r-tabs-nav {
+    display: none; }
+  .r-tabs .r-tabs-accordion-title {
+    display: block; } }
+
+.p-button--primary {
+  border: 1px solid #cdcdcd;
+  color: #000; }
+
+.external {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23007aa6' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23007aa6' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23007aa6' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,662 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <title>snapcraft - Snaps are universal Linux packages</title>
+
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
+        <!-- End Google Tag Manager -->
+
+        <script>
+        /* HTML5 element support */
+        for(var e,l='article aside footer header nav section time'.split(' ');e=l.pop();document.createElement(e));
+        </script>
+
+        <meta name="description" content="Introducing snaps and commands to install and remove them on Ubuntu 16.04 LTS.">
+
+        <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://assets.ubuntu.com/v1/3361409d-apple-touch-icon-144x144-precomposed.png" />
+        <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://assets.ubuntu.com/v1/5fe4d3c8-apple-touch-icon-114x114-precomposed.png" />
+        <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png" />
+        <link rel="apple-touch-icon-precomposed" href="https://assets.ubuntu.com/v1/cc66da65-apple-touch-icon-precomposed.png" />
+
+        <link rel="stylesheet" href="/static/css/index.css">
+    </head>
+
+    <body class="">
+        <!-- Google Tag Manager (noscript) -->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript) -->
+
+        <header class="banner global" role="banner">
+            <nav role="navigation" class="nav-primary" id="nav-primary">
+                <span class="accessibility-aid">
+                    <a href="#main-content">Jump to main content</a>
+                </span>
+                <div class="logo">
+                    <a href="/">
+                        <img src="https://assets.ubuntu.com/v1/d45097a4-snapcraft.io-logotype.svg" alt="Snapcraft.io">
+                    </a>
+                </div>
+                <div id="nav">
+                    <div class="nav-toggle">
+                        <a href="#nav" class="nav-toggle__link open"></a>
+                        <a href="#" class="nav-toggle__link close"></a>
+                    </div>
+                    
+                    <ul>
+                        <li><a href="https://build.snapcraft.io">Build</a></li>
+                        <li ><a href="/docs">Docs</a></li>
+                        <li><a class="external" href="https://tutorials.ubuntu.com">Tutorials</a></li>
+                        <li><a class="external" href="https://forum.snapcraft.io/">Forum</a></li>
+                    </ul>
+                </div>
+            </nav>
+        </header>
+
+        <div class="page-content">
+        <section class="row hero-row no-border">
+        <div class="wrapper">
+            <div class="eight-col">
+                <h1 id="snapcraft_home_banner" class="accessibility-aid">Snapcraft</h1>
+                <p class="intro">Package any app for every Linux desktop,
+                server, cloud or device, and deliver updates directly.</p>
+                <p>
+                  <a href="https://tutorials.ubuntu.com/tutorial/create-your-first-snap"><button class="p-button--primary" style="margin-right: 0.75rem; margin-bottom: 0.75rem;">Learn to craft your first snap</button></a> or <a href="https://build.snapcraft.io" class="external">Auto-build and publish from your GitHub repos</a>
+                </p>
+            </div>
+            <div class="twelve-col">
+                <ul class="inline-logos equal-height">
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-ubuntu"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/c086ad34-logo-ubuntu_st_no-black_orange-hex.svg" alt="Ubuntu" /></a>
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-arch-linux"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/e0b23092-archlinux.svg" alt="Arch Linux" /></a>
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-debian"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/2eafb62e-openlogo.svg" alt="Debian" /></a>
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-gentoo"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/b6fa25ef-Gentoo-trans02.png" alt="Gentoo" /></a>
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-fedora"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/1a53bedd-fedora.svg" alt="Fedora" /></a>
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-opensuse"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/06469a26-official-logo-color.svg" alt="openSUSE" /></a>
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-oe-yocto"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/d243274d-openembedded-logo.svg" alt="OpenEmbedded" /></a>
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-oe-yocto"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/d9a1a359-yocto-project-transp.png" alt="Yocto Project" />
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-openwrt"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/d4981274-Openwrt_Logo.svg" alt="OpenWrt" /></a>
+                    </li>
+                    <li class="inline-logos__item box">
+                        <a href="/docs/core/install-solus"><img class="inline-logos__image" src="https://assets.ubuntu.com/v1/5cb36534-Solus_With_Text.png" alt="Solus" /></a>
+                    </li>
+                </ul>
+
+            </div>
+        </div>
+    </section>
+    <section id="snapcraft_home_install" class="row hero-row no-border row-grey">
+        <div class="wrapper">
+            <div class="twelve-col">
+                <div class="equal-height--vertical-divider">
+                  <div class="equal-height--vertical-divider__item four-col">
+                      <h3>Quick to install</h3>
+                      <p>Snaps are quick to install, easy to create, safe to run, and they
+                      update automatically and transactionally so your app is always fresh and
+                      never broken.</p>
+                      <p><a href="/docs/core/install">Install snapd&nbsp;&rsaquo;</a></p>
+                  </div>
+                  <div class="equal-height--vertical-divider__item four-col">
+                      <h3>Work anywhere</h3>
+                      <p>Snaps aim to work on any distribution or device, from IoT devices to
+                      servers, desktops to mobile devices.</p>
+                      <p><a href="https://github.com/snapcore/snapd" class="external">Build snapd from source</a></p>
+                  </div>
+                  <div class="equal-height--vertical-divider__item four-col last-col">
+                      <h3>GitHub and beyond</h3>
+                      <p>The public collection of snaps includes the best of GitHub and beyond,
+                      so you have the whole world of Linux at your fingertips.</p>
+                      <p><a href="https://build.snapcraft.io" class="external">Build a snap from GitHub</a></p>
+                  </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="snapcraft_home_featured-snaps" class="row">
+        <div class="wrapper">
+            <div class="seven-col">
+                <h2>Featured snaps</h2>
+            </div>
+
+            <ul class="grid-list twelve-col no-bullets no-margin-bottom equal-height">
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/2ca6d139-atom.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Atom</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/13929d8e-brackets.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Brackets</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/3f07652c-brave.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Brave</h3>
+                    </div>
+                </li>
+
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/2863cbf1-code.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Code</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/4eca1f4e-discord.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Discord</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/58652d89-gogland.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Gogland</h3>
+                    </div>
+                </li>
+
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/8f0cd431-golang.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Golang</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/86bae242-heroku.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Heroku</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/f4b790e9-hiri.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Hiri</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-row">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/8a19c654-pycharm.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>PyCharm</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-row">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/a01512ec-teleconsole.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Teleconsole</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-col last-row">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/edab8e40-wavebox.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Wavebox</h3>
+                    </div>
+                </li>
+            </ul>
+
+            <div class="twelve-col">
+                <p class="complementing-note">Check out snaps on <a href="https://uappexplorer.com/snaps">uappexplorer.com</a>, or use the command line to install any of these great snaps.</p>
+            </div>
+        </div>
+    </section>
+
+    <section id="snapcraft_home_how-snaps-work" class="row">
+        <div class="wrapper">
+            <div class="eight-col">
+                <h2>How do snaps work?</h2>
+                <p>A snap is a fancy zip file containing an application together
+                with its dependencies, and a description of how it should safely
+                run on your system, especially the different ways it should
+                talk to other software.</p>
+                <p>Snaps are designed to be secure, sandboxed,
+                containerised applications isolated from the underlying system
+                and from other applications. Snaps allow the safe installation
+                of apps from any vendor on mission critical devices and desktops.</p>
+
+                <p>Try this: (you may need to <a href="/docs/core/install">install snapd</a>)</p>
+
+                <pre class="command-line code-block">
+<code>$ sudo snap install hello-world</code></pre>
+
+                <p>Now you have installed a snap. You can take a look inside the
+                snap, since it is a new directory on your system:</p>
+
+                <pre class="command-line code-block">
+<code>$ cd /snap/hello-world/current/
+
+$ tree
+.
+├── <span class="directory-highlight">bin</span>                 ← this directory structure is just for convenience
+│   ├── <span class="bin-highlight">echo</span>              there is no hardcoded structure requirement other
+│   ├── <span class="bin-highlight">env</span>               than meta/snap.yaml
+│   ├── <span class="bin-highlight">evil</span>
+│   ├── <span class="bin-highlight">sh</span>
+│   ├── <span class="bin-highlight">showdev</span>
+│   └── <span class="bin-highlight">usehw</span>
+└── <span class="directory-highlight">meta</span>                ← your snap must have this directory
+    ├── <span class="image-highlight">icon.png</span>
+    └── snap.yaml       ← this is the required metadata</code></pre>
+
+                <p>So to create a snap, just put all the files you need
+                into a directory, use whatever subdirectory structure you want. That
+                directory will be compressed into a <dfn>squashfs</dfn> — a zipped directory —
+                which will be mounted at
+                <code class="command-inline">/snap/&lt;name&gt;/current</code> when
+                the snap is installed. Your snap apps will know where they are mounted
+                because that is provided as the
+                <code class="command-inline">$SNAP</code> environment variable
+                when they are run.</p>
+
+                <p>The only requirement of a snap structure is that it
+                contains a file called <code class="command-inline">meta/snap.yaml</code>, which describes security requirements
+                and how the snap should integrate with other parts of the system.
+                Let’s take a look at that <code class="command-inline">snap.yaml</code>
+                for the <code class="command-inline">hello-world</code> snap:</p>
+
+                <pre class="command-line code-block">
+<code>$ cat meta/snap.yaml
+<span class="key-highlight">name:</span> hello-world
+<span class="key-highlight">version:</span> 6.1
+<span class="key-highlight">architectures:</span> [ all ]
+<span class="key-highlight">summary:</span> <span class="string-highlight">"The 'hello-world' of snaps"</span>
+<span class="key-highlight">description:</span> <span class="string-highlight">|
+    This is a simple snap example that includes a few interesting binaries
+    to demonstrate snaps and their confinement.
+    * hello-world.env  - dump the env of commands run inside app sandbox
+    * hello-world.evil - show how snappy sandboxes binaries
+    * hello-world.sh   - enter interactive shell that runs in app sandbox
+    * hello-world      - simply output text</span>
+<span class="key-highlight">apps:</span>
+  <span class="key-l2-highlight">env:</span>
+    <span class="key-l3-highlight">command:</span> bin/env
+  <span class="key-l2-highlight">evil:</span>
+    <span class="key-l3-highlight">command:</span> bin/evil
+  <span class="key-l2-highlight">sh:</span>
+    <span class="key-l3-highlight">command:</span> bin/sh
+  <span class="key-l2-highlight">hello-world:</span>
+    <span class="key-l3-highlight">command:</span> bin/echo</code></pre>
+
+                <p>The initial metadata describes the snap. The <code class="command-inline">version</code> is purely for humans; the snap system
+                won’t ever treat it as special or try to compare versions
+                between snaps.</p>
+
+                <p>Next is a list of “apps” provided by this snap. Each app
+                is explicitly named (“<code class="command-inline">env</code>”, “<code class="command-inline">evil</code>”, ‘<code class="command-inline">sh</code>”, and “<code class="command-inline">hello-world</code>”) and each
+                gets a distinctive command, which is path relative to <code class="command-inline">$SNAP</code>. The name
+                of the app doesn’t have to match the command.</p>
+                <p>The special app here is “<code class="command-inline">hello-world</code>”, because it has the same name
+                as the snap itself. This makes it the default app in the snap, so you can run
+                it just by typing “<code class="command-inline">hello-world</code>” after the snap is installed. The others
+                need to be namespaced, so “<code class="command-inline">hello-world.evil</code>” will execute the <code class="command-inline">bin/evil</code>
+                command in the snap.</p>
+                <p>A snap can declare daemons to be started as well. This one just
+                describes some apps.</p>
+            </div>
+
+            <div class="four-col last-col">
+                <ul class="inline-logos">
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg" alt="intel" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/b5352dc1-logo-arm.svg" alt="arm" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/47e40767-power8.png" alt="power8" />
+                    </li>
+                </ul>
+            </div>
+
+            <div id="snapcraft_home_how-snaps-work_read-only" class="eight-col">
+                <h3>Snaps are read-only and have segregated data stores</h3>
+                <p>Snaps are read-only for security. The aim is to prevent a hostile
+                party from sneakily changing the software on your machine, so you
+                cannot modify a snap that is installed on your system. This also
+                means you can always check the signature on the snap, even long
+                after you installed it, to make sure it is still exactly the
+                software you intended. If you want to modify a snap, you can
+                usually build your own version of it, especially if it is open
+                source.</p>
+                <p>So where can a snap write data? Each snap gets its own set of
+                writable directories which have specific properties. There are
+                two directories which the snap can write to independent of the
+                user. One of these is versioned: each time the snap is upgraded
+                the data is saved and the new snap revision can upgrade its copy.
+                The other common data directory is not versioned, and is used
+                for big blobs of data that you don’t want to duplicate across
+                revisions of the snap:</p>
+
+                <pre class="command-line code-block">
+<code>/var/snap/&lt;name&gt;/current/  ← $SNAP_DATA is the versioned snap data directory
+/var/snap/&lt;name&gt;/common/   ← $SNAP_COMMON will not be versioned on upgrades</code></pre>
+
+                <p>Typically, configuration is stored in one of these, along with
+                system-wide data for the snap.</p>
+
+                <p>There are an equivalent two writable directories for each
+                snap in the user’s home directory, which can be used to store snap data
+                specific to that user:</p>
+
+                <pre class="command-line code-block">
+<code>~/snap/&lt;name&gt;/current/      ← $SNAP_USER_DATA that can be rolled back
+~/snap/&lt;name&gt;/common/       ← $SNAP_USER_COMMON unversioned user-specific data</code></pre>
+
+                <p>This way applications can be immutable for security reasons,
+               while still offering a full and rich user experience. To learn
+               more about the makeup of a snap please see the
+               <a href="/docs/snaps/structure">snap
+               architecture article.</a></p>
+            </div>
+
+            <div id="snapcraft_home_how-snaps-work_integration" class="eight-col">
+                <h3>Snap integration with interfaces, plugs and slots</h3>
+                <p> Snaps are safely confined in their separate sandboxes by
+                sophisticated kernel security mechanisms. That means that snaps
+                can’t peek at your data — other than the data you give
+                them — if they are compromised or malicious. But what if you need your snap
+                to talk to another snap? For example, what if your snap needs to
+                talk to a database?</p>
+                <p>It can use “interfaces” — standard and well-defined ways to
+                provide and consume services from one another. Snaps can offer
+                “slots” to provide services, and declare “plugs” that connect
+                to other snap slots to consume those services. Imagine two snaps
+                A and B that need to talk to each other:</p>
+
+                <p class="diagram">
+                    <img src="https://assets.ubuntu.com/v1/74bd0daf-interfaces-+plugs-and-slots.svg" />
+                </p>
+
+                <p class="complementing-note">These two snaps can be connected because they have a plug
+                and a slot with a matching interface.</p>
+
+                <p>The interfaces are declared in the <code class="command-inline">snap.yaml</code> metadata:</p>
+                <p class="diagram">
+                    <img src="https://assets.ubuntu.com/v1/1c1706c0-Update-Snapcraft%28dot%29io+-+YAML+metadata.svg" />
+                </p>
+
+                <p>There are <a class="external" href="/docs/reference/interfaces">
+                many interfaces defined</a> that can be used by
+                snap developers to describe the ways their snaps should be
+                connected. A snap can be connected to the host system OS
+                using plugs, too, which is how it can access shared user
+                documents or other services like OpenGL.</p>
+
+                <p>Snaps can share files with other snaps from the same vendor,
+                or with community-maintained shared snaps which act as libraries
+                of common data or code, for
+                example using the content-sharing interface. This reduces duplication while still ensuring rigorous
+                security and update control.</p>
+
+                <p>When you install a snap, the system will automatically connect
+                up the standard, safe plugs and slots. For example, your new game
+                will automatically get access to the OpenGL libraries on your
+                system because that’s considered normal behaviour for a game.
+                But there may be other plugs and slots you can connect up by
+                choice, and  snaps will document those individually.</p>
+            </div>
+            <div id="snapcraft_home_how-snaps-work_architecture" class="eight-col">
+                <h3>The architecture of a snappy system</h3>
+                <p>So a snappy system has a collection of snaps, each of which
+                is read-only, each of which has its own set of independent
+                writable directories, and each of which can talk to other snaps
+                and the host OS through a set of plugs and slots with matching
+                interfaces.</p>
+
+                <p>
+                    <img class="diagram--wide" src="https://assets.ubuntu.com/v1/143dff64-Update-Snapcraft%28dot%29io-architecture_v2.svg" />
+                </p>
+
+                <p>The snap system will present all the snap apps under <code class="command-inline">/snap/bin/</code>,
+                so with that on your <code class="command-inline">$PATH</code> you can easily run snap commands. It
+                will also integrate all the snap daemons (services) with your
+                init system so that they are automatically started and stopped
+                as needed.</p>
+            </div>
+        </div>
+    </section>
+
+    <section id="snapcraft_home_using-snaps" class="row">
+        <div class="wrapper">
+            <div class="eight-col">
+                <h2>Using snaps — the snappy “hello world” tour</h2>
+                <p>To install a snap, you’ll start by looking for available snaps.
+                Anybody can publish a snap, but if you search the default Ubuntu
+                store you will only see snaps that have been reviewed and judged
+                to be of good quality, and which can be installed securely. We
+                call these the ‘promoted’ snaps, and you can search them for a
+                matching name:</p>
+
+
+
+<pre class="command-line code-block"><code>$ snap find hello
+Name         Version  Developer  Notes  Summary
+hello        2.10     canonical  -      GNU Hello, the "hello world" snap
+hello-huge   1.0      noise      -      A really big snap
+hello-world  6.1      canonical  -      Hello world example</code></pre>
+
+                <p>In the future, you will be able to refine <code class="command-inline">snap find</code> queries with more parameters.</p>
+
+                <p>These examples use the Ubuntu store; your snap implementation
+                might be different. Other stores are available, and it’s easy
+                to create your own. There is an open-source
+                <a class="external" href="https://github.com/noise/snapstore">simple snap store</a>
+                implementation to get you started making your own store.</p>
+
+                <p>We’ll start by installing GNU Hello, from the Free Software Foundation:</p>
+
+                <pre class="command-line code-block"><code>$ sudo snap install hello</code></pre>
+
+                <p>Just like any other app, we can then launch the snap  from the
+                command line, or from the desktop if it has a launcher:</p>
+
+
+<pre class="command-line code-block"><code>$ hello
+Hello, world!</code></pre>
+
+                <p>See the snaps installed on your system with “<code class="command-inline">snap list</code>”, which
+                will also tell you the software version, the unique revision, the
+                developer of the installed snap, and any extra information such
+                as whether the snap is in <a href="/docs/reference/confinement">developer mode</a> or not:</p>
+
+
+<pre class="command-line code-block"><code>$ snap list
+Name     Version   Rev     Developer     Notes
+hello    2.10      26      canonical     -
+core     16.04-55  109     canonical     -
+snapweb  0.17      21      canonical     -</code></pre>
+            </div>
+            <div id="snapcraft_home_using-snaps_fresh" class="eight-col">
+                <h3>Always fresh – update fast and reliably</h3>
+                <p>Snaps are updated automatically in the background every day.
+                You can manually get the latest version of all your snaps with
+                “<code class="command-inline">snap refresh</code>”, which will bring you completely up to date for all
+                snaps, unless you specify particular snaps to refresh.</p>
+
+
+<pre class="command-line code-block"><code>$ sudo snap refresh hello
+hello already up to date
+$ sudo snap refresh
+core 64.75 MB [=====================================>___]   12s
+core updated</code></pre>
+            </div>
+
+            <div id="snapcraft_home_using-snaps_revert" class="eight-col">
+                <h3>Revert if something goes wrong</h3>
+                <p>It is simple to roll
+                back to a previous version of an application for any reason.</p>
+
+
+<pre class="command-line code-block"><code>$ snap list
+ Name              Version               Rev  Developer  Notes
+ hello-world       6.1                   26   canonical  -
+
+ $ sudo snap revert hello-world
+ Name             Version                Rev  Developer  Notes
+ hello-world      6.0                    25   canonical  -</code></pre>
+            </div>
+
+            <div id="snapcraft_home_using-snaps_channels" class="eight-col">
+                <h3>Stable, candidate, beta and edge channels</h3>
+                <p>Developers can release stable, candidate, beta and edge versions
+                of a snap, at the same time, to engage with a community who are
+                willing to test upcoming changes. You decide how close to the
+                leading edge you want to be.</p>
+
+                <p>By default, snaps are installed from the “<code class="command-inline">stable</code>” channel. By convention,
+                developers use the “<code class="command-inline">candidate</code>” channel to provide a heads-up of
+                a new stable revision, putting it in “<code class="command-inline">candidate</code>” a few days before
+                “<code class="command-inline">stable</code>” so that people can test it out. The “<code class="command-inline">beta</code>” channel is for
+                unfinished but interesting milestones, and the “<code class="command-inline">edge</code>” channel is
+                conventionally used for regular or daily development builds that
+                have passed some lightweight smoke-testing.</p>
+
+
+<pre class="command-line code-block"><code>$ sudo snap refresh hello --channel=beta
+hello (beta) 1.2 installed</code></pre>
+
+                <p>Now, you can run the beta version of the snap:</p>
+
+
+<pre class="command-line code-block"><code>$ hello
+Hello, snap padawan!</code></pre>
+
+                <p>You can also install a snap from the “<code class="command-inline">beta</code>” channel directly:</p>
+
+
+<pre class="command-line code-block"><code>$ sudo snap install hello --beta
+Hello (beta) 1.2 installed</code></pre>
+            </div>
+        </div>
+    </section>
+
+    <section id="snapcraft_home_get-crafting" class="row">
+        <div class="wrapper">
+            <div class="eight-col">
+                <h2>Get crafting!</h2>
+                <p>Snaps have a very simple internal structure — you can easily
+                craft them by hand.</p>
+                <p>But if your code is on GitHub, the easiest way to build a snap is with <a class="external" href="https://build.snapcraft.io/">our auto-build service</a>. Every commit is auto-built, and every successful build is released to the “<code class="command-inline">edge</code>” channel.</p>
+                <p>Otherwise, you can use <dfn>Snapcraft</dfn>, which
+                allows building from source and from existing packages. Snapcraft
+                also handles releasing your snaps to the world.</p>
+                <p>Read how to create a snap and join the snap-crafting community
+                &mdash; we hang out in the <a class="external" href="https://webchat.freenode.net/?channels=snappy">#snappy channel on Freenode</a> or
+                <a href="mailto:snapcraft@lists.snapcraft.io">snapcraft@lists.snapcraft.io</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="row row-grey equal-height">
+    <div class="wrapper equal-height--vertical-divider">
+        <div class="six-col equal-height--vertical-divider__item">
+            <h2>Learn more</h2>
+            <p>Want to know more about snaps, <code class="command-inline">snapd</code>, Snapcraft and Ubuntu Core?</p>
+            <ul class="no-bullets">
+                <li><a href="https://forum.snapcraft.io/" class="external">Forum</a></li>
+                <li><a href="https://rocket.ubuntu.com/channel/snapcraft" class="external">Real-time chat</a></li>
+                <li><a href="http://stackoverflow.com/questions/ask?tags=snapcraft" class="external">Snapcraft on Stack Overflow</a></li>
+            </ul>
+        </div>
+        <div class="six-col last-col equal-height--vertical-divider__item">
+            <h2>Contribute</h2>
+            <p>Interested in helping build Snapcraft and expand its reach?</p>
+            <ul class="no-bullets">
+                <li><a href="https://github.com/canonical-websites/snapcraft.io" class="external">Fork this website on GitHub</a></li>
+                <li><a href="https://github.com/snapcore/snapcraft" class="external">Fork snapcraft on GitHub</a></li>
+                <li><a href="https://github.com/snapcore/snapd" class="external">Fork snapd on GitHub</a></li>
+            </ul>
+        </div>
+    </div>
+</section>
+
+
+</div>
+
+<div class="wrapper">
+    <footer class="footer">
+      <div class="footer__social right">
+        <h3 class="footer__heading">Follow us</h3>
+        <ul class="social-list inline-list clearfix">
+          <li class="social-list__item">
+            <a href="https://twitter.com/snapcraftio" class="social-list__item--twitter">Share on Twitter</a>
+          </li>
+          <li class="social-list__item">
+            <a href="https://plus.google.com/+SnapcraftIo" class="social-list__item--google-plus">Share on Google plus</a>
+          </li>
+          <li class="social-list__item">
+            <a href="https://www.facebook.com/snapcraftio" class="social-list__item--facebook">Share on Facebook</a>
+          </li>
+          <li class="social-list__item">
+            <a href="https://www.youtube.com/snapcraftio" class="social-list__item--youtube">Share on YouTube</a>
+          </li>
+        </ul>
+      </div>
+
+      <p class="footer__text">&copy; 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+
+<ul class="footer__links">
+    <li class="footer__list-item"><a href="http://www.ubuntu.com/legal">Legal information</a><span class="footer__dot"> &#183;</span></li>
+    <li class="footer__list-item"><a href="https://github.com/ubuntudesign/snapcraft.io/issues/new">Report a bug on this site</a><span class="footer__dot"> &#183;</span></li>
+    <li class="footer__list-item"><a href="http://status.snapcraft.io/">Service status</a></li>
+</ul>
+
+<p class="note six-col">Yocto Project and all related marks and logos are trademarks of The Linux Foundation. This website is not, in any way, endorsed by the Yocto Project or The Linux Foundation. Some artwork by the <a href="http://www.gnome.org">GNOME Project</a>, licensed <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>.</p>
+
+<span class="accessibility-aid"><a href="#">Go to the top of the page</a></span>
+
+    </footer>
+</div>
+
+    </body>
+</html>

--- a/tests.py
+++ b/tests.py
@@ -9,10 +9,10 @@ class WebAppTestCase(unittest.TestCase):
         self.app = app.app.test_client()
         self.app.testing = True
 
-    def test_no_homepage(self):
+    def test_homepage(self):
         response = self.app.get('/')
-        assert response.status_code == 404
-        assert "Page not found" in str(response.data)
+        assert response.status_code == 200
+        assert "Ubuntu and Canonical are registered" in str(response.data)
 
     def test_redirect_to_add_slash(self):
         response = self.app.get('/canonical-livepatch')


### PR DESCRIPTION
**Please review https://github.com/canonical-websites/snapcraft-flask/pull/58 first**

Since K8s won't let me do the routing quite as I wanted, it's easier to just move the homepage into this app.

Ultimately this app should serve the homepage anyway. The way it's done here isn't ideal, so I've filed https://github.com/canonical-websites/snapcraft-flask/issues/59 to do soon, and made it high priority.

QA
--

``` bash
./run
```

Go to <http://127.0.0.1:8022>, see that it looks identical to <https://snapcraft.io>.

Now go to <http://127.0.0.1:8022/lxd/> and see a snap details page. Also go to <http://127.0.0.1:8022/missing> and see a 404 page.